### PR TITLE
feat(detail): Implement Podcast Detail screen and navigation

### DIFF
--- a/Spokast/Features/Home/HomeCoordinator.swift
+++ b/Spokast/Features/Home/HomeCoordinator.swift
@@ -9,6 +9,7 @@ import Foundation
 import UIKit
 
 final class HomeCoordinator: Coordinator {
+    
     var navigationController: UINavigationController
 
     init(navigationController: UINavigationController) {
@@ -19,7 +20,18 @@ final class HomeCoordinator: Coordinator {
         let apiService = APIService()
         let viewModel = HomeViewModel(apiService: apiService)
         let viewController = HomeViewController(viewModel: viewModel)
-
+        
+        viewController.delegate = self
+        
         navigationController.pushViewController(viewController, animated: true)
+    }
+}
+
+// MARK: - HomeViewControllerDelegate
+extension HomeCoordinator: HomeViewControllerDelegate {
+    
+    func didSelectPodcast(_ podcast: Podcast) {
+        print("Coordinator did receive tap for podcast: \(podcast.collectionName)")
+        
     }
 }

--- a/Spokast/Features/Home/HomeCoordinator.swift
+++ b/Spokast/Features/Home/HomeCoordinator.swift
@@ -29,9 +29,9 @@ final class HomeCoordinator: Coordinator {
 
 // MARK: - HomeViewControllerDelegate
 extension HomeCoordinator: HomeViewControllerDelegate {
-    
     func didSelectPodcast(_ podcast: Podcast) {
-        print("Coordinator did receive tap for podcast: \(podcast.collectionName)")
-        
+        let detailViewModel = PodcastDetailViewModel(podcast: podcast)
+        let detailViewController = PodcastDetailViewController(viewModel: detailViewModel)
+        navigationController.pushViewController(detailViewController, animated: true)
     }
 }

--- a/Spokast/Features/Home/Views/HomeViewController.swift
+++ b/Spokast/Features/Home/Views/HomeViewController.swift
@@ -1,4 +1,3 @@
-//
 //  HomeViewController.swift
 //  Spokast
 //
@@ -8,11 +7,17 @@
 import Foundation
 import UIKit
 
+// MARK: - HomeViewControllerDelegate
+protocol HomeViewControllerDelegate: AnyObject {
+    func didSelectPodcast(_ podcast: Podcast)
+}
+
 final class HomeViewController: UIViewController {
 
     // MARK: - Properties
     private let viewModel: HomeViewModel
     private var homeView: HomeView?
+    weak var delegate: HomeViewControllerDelegate?
 
     // MARK: - Initialization
     init(viewModel: HomeViewModel) {
@@ -35,7 +40,11 @@ final class HomeViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupView()
+        
         homeView?.podcastsTableView.dataSource = self
+        homeView?.podcastsTableView.delegate = self
+        
+        homeView?.podcastsTableView.register(PodcastCell.self, forCellReuseIdentifier: PodcastCell.reuseIdentifier)
         viewModel.fetchPodcasts()
     }
 
@@ -46,7 +55,6 @@ final class HomeViewController: UIViewController {
 
 // MARK: - HomeViewModelDelegate
 extension HomeViewController: HomeViewModelDelegate {
-
     func didFetchPodcastsSuccessfully() {
         homeView?.podcastsTableView.reloadData()
         print("Successfully fetched podcasts!")
@@ -66,7 +74,7 @@ extension HomeViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: PodcastCell.reuseIdentifier, for: indexPath) as? PodcastCell else {
-            return UITableViewCell()
+            fatalError("Could not dequeue cell with identifier: \(PodcastCell.reuseIdentifier)")
         }
         
         let podcast = viewModel.podcasts[indexPath.row]
@@ -78,5 +86,16 @@ extension HomeViewController: UITableViewDataSource {
         )
         
         return cell
+    }
+}
+
+// MARK: - UITableViewDelegate
+extension HomeViewController: UITableViewDelegate {
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        
+        let selectedPodcast = viewModel.podcasts[indexPath.row]
+        delegate?.didSelectPodcast(selectedPodcast)
     }
 }

--- a/Spokast/Features/PodcastDetail/ViewModels/PodcastDetailViewModel.swift
+++ b/Spokast/Features/PodcastDetail/ViewModels/PodcastDetailViewModel.swift
@@ -1,0 +1,41 @@
+//
+//  PodcastDetailViewModel.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 09/12/25.
+//
+
+import Foundation
+
+final class PodcastDetailViewModel {
+
+    // MARK: - Properties
+    private let podcast: Podcast
+    
+    // MARK: - Initialization
+    init(podcast: Podcast) {
+        self.podcast = podcast
+    }
+    
+    // MARK: - Outputs
+    var title: String {
+        return podcast.collectionName
+    }
+    
+    var artist: String {
+        return podcast.artistName
+    }
+    
+    var coverImageURL: URL? {
+        let urlString = podcast.artworkUrl600 ?? podcast.artworkUrl100
+        return URL(string: urlString)
+    }
+    
+    var genre: String {
+        return podcast.primaryGenreName ?? "Podcast"
+    }
+    
+    var description: String {
+        return "Podcast details and episodes coming soon..."
+    }
+}

--- a/Spokast/Features/PodcastDetail/Views/PodcastDetailView.swift
+++ b/Spokast/Features/PodcastDetail/Views/PodcastDetailView.swift
@@ -1,0 +1,95 @@
+//
+//  PodcastDetailView.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 19/12/25.
+//
+
+import Foundation
+import UIKit
+
+final class PodcastDetailView: UIView {
+
+    // MARK: - UI Components
+    let imageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFill
+        imageView.layer.cornerRadius = 12
+        imageView.clipsToBounds = true
+        imageView.backgroundColor = .secondarySystemBackground
+        return imageView
+    }()
+
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .systemFont(ofSize: 22, weight: .bold)
+        label.textColor = .label
+        label.numberOfLines = 0
+        label.textAlignment = .center
+        return label
+    }()
+
+    private let artistLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .systemFont(ofSize: 18, weight: .medium)
+        label.textColor = .secondaryLabel
+        label.numberOfLines = 1
+        label.textAlignment = .center
+        return label
+    }()
+    
+    private let genreLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .systemFont(ofSize: 14, weight: .regular)
+        label.textColor = .tertiaryLabel
+        label.textAlignment = .center
+        return label
+    }()
+
+    private lazy var mainStackView: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [imageView, titleLabel, artistLabel, genreLabel])
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        stack.spacing = 16
+        stack.alignment = .center
+        return stack
+    }()
+
+    // MARK: - Initialization
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Public Configuration
+    func configure(with viewModel: PodcastDetailViewModel) {
+        titleLabel.text = viewModel.title
+        artistLabel.text = viewModel.artist
+        genreLabel.text = viewModel.genre.uppercased()
+    }
+
+    // MARK: - UI Setup
+    private func setupUI() {
+        backgroundColor = .systemBackground
+        
+        addSubview(mainStackView)
+        
+        NSLayoutConstraint.activate([
+            imageView.heightAnchor.constraint(equalToConstant: 200),
+            imageView.widthAnchor.constraint(equalToConstant: 200),
+            
+            mainStackView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 32),
+            mainStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24),
+            mainStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -24)
+        ])
+    }
+}

--- a/Spokast/Features/PodcastDetail/Views/PodcastDetailViewController.swift
+++ b/Spokast/Features/PodcastDetail/Views/PodcastDetailViewController.swift
@@ -1,0 +1,57 @@
+//
+//  PodcastDetailViewController.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 19/12/25.
+//
+
+import Foundation
+import UIKit
+import Kingfisher
+
+final class PodcastDetailViewController: UIViewController {
+
+    // MARK: - Properties
+    private let viewModel: PodcastDetailViewModel
+    private var customView: PodcastDetailView?
+
+    // MARK: - Initialization
+    init(viewModel: PodcastDetailViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+    override func loadView() {
+        self.customView = PodcastDetailView()
+        self.view = customView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupConfiguration()
+    }
+    
+    // MARK: - Configuration
+    private func setupConfiguration() {
+        guard let customView = customView else { return }
+        
+        customView.configure(with: viewModel)
+        
+        if let url = viewModel.coverImageURL {
+            customView.imageView.kf.setImage(
+                with: url,
+                placeholder: UIImage(systemName: "photo"),
+                options: [
+                    .transition(.fade(0.3)),
+                    .cacheOriginalImage
+                ]
+            )
+        }
+    }
+}

--- a/Spokast/Models/Podcast.swift
+++ b/Spokast/Models/Podcast.swift
@@ -12,6 +12,8 @@ struct Podcast: Decodable {
     let collectionName: String
     let artworkUrl100: String
     let feedUrl: String?
+    let artworkUrl600: String?
+    let primaryGenreName: String?
 }
 
 struct SearchResult: Decodable {


### PR DESCRIPTION
### Summary
This PR introduces the Podcast Detail screen. It implements the MVVM-C architecture for the detail flow, handling data presentation and navigation from the Home screen.

### Key Changes
* **Architecture:** Implements `PodcastDetailViewModel` to handle presentation logic and `PodcastDetailViewController` to manage the UI lifecycle.
* **UI:** Adds `PodcastDetailView` using programmatic Auto Layout (StackView) and integrates **Kingfisher** for high-resolution image loading.
* **Navigation:** Updates `HomeCoordinator` to conform to `HomeViewControllerDelegate`, enabling loose coupling navigation to the detail screen.
* **Model:** Updates `Podcast` struct to support high-resolution artwork and genre data.

### How to Test
1.  Launch the app.
2.  Tap on any podcast in the Home list.
3.  Verify that the Detail screen opens.
4.  Check if the high-resolution image, title, artist, and genre are displayed correctly.