### PR TITLE
feat(detail): Fetch and display podcast episodes

### DIFF
--- a/Spokast/Features/Home/HomeCoordinator.swift
+++ b/Spokast/Features/Home/HomeCoordinator.swift
@@ -30,7 +30,8 @@ final class HomeCoordinator: Coordinator {
 // MARK: - HomeViewControllerDelegate
 extension HomeCoordinator: HomeViewControllerDelegate {
     func didSelectPodcast(_ podcast: Podcast) {
-        let detailViewModel = PodcastDetailViewModel(podcast: podcast)
+        let service = APIService()
+        let detailViewModel = PodcastDetailViewModel(podcast: podcast, service: service)
         let detailViewController = PodcastDetailViewController(viewModel: detailViewModel)
         navigationController.pushViewController(detailViewController, animated: true)
     }

--- a/Spokast/Features/PodcastDetail/Views/PodcastDetailView.swift
+++ b/Spokast/Features/PodcastDetail/Views/PodcastDetailView.swift
@@ -11,6 +11,15 @@ import UIKit
 final class PodcastDetailView: UIView {
 
     // MARK: - UI Components
+    lazy var tableView: UITableView = {
+        let tableView = UITableView()
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.backgroundColor = .systemBackground
+        tableView.separatorStyle = .singleLine
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "EpisodeCell")
+        return tableView
+    }()
+    
     let imageView: UIImageView = {
         let imageView = UIImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
@@ -50,13 +59,19 @@ final class PodcastDetailView: UIView {
         return label
     }()
 
-    private lazy var mainStackView: UIStackView = {
+    private lazy var headerStackView: UIStackView = {
         let stack = UIStackView(arrangedSubviews: [imageView, titleLabel, artistLabel, genreLabel])
         stack.translatesAutoresizingMaskIntoConstraints = false
         stack.axis = .vertical
         stack.spacing = 16
         stack.alignment = .center
         return stack
+    }()
+    
+    private let headerContainerView: UIView = {
+        let view = UIView()
+        view.frame = CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 400)
+        return view
     }()
 
     // MARK: - Initialization
@@ -75,21 +90,54 @@ final class PodcastDetailView: UIView {
         titleLabel.text = viewModel.title
         artistLabel.text = viewModel.artist
         genreLabel.text = viewModel.genre.uppercased()
+        layoutTableHeaderView()
     }
 
     // MARK: - UI Setup
     private func setupUI() {
         backgroundColor = .systemBackground
+        addSubview(tableView)
+        headerContainerView.addSubview(headerStackView)
         
-        addSubview(mainStackView)
+        let stackLeading = headerStackView.leadingAnchor.constraint(equalTo: headerContainerView.leadingAnchor, constant: 24)
+        let stackTrailing = headerStackView.trailingAnchor.constraint(equalTo: headerContainerView.trailingAnchor, constant: -24)
+      
+        stackLeading.priority = UILayoutPriority(999)
+        stackTrailing.priority = UILayoutPriority(999)
         
         NSLayoutConstraint.activate([
             imageView.heightAnchor.constraint(equalToConstant: 200),
             imageView.widthAnchor.constraint(equalToConstant: 200),
             
-            mainStackView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor, constant: 32),
-            mainStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24),
-            mainStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -24)
+            headerStackView.topAnchor.constraint(equalTo: headerContainerView.topAnchor, constant: 32),
+            headerStackView.bottomAnchor.constraint(equalTo: headerContainerView.bottomAnchor, constant: -32),
+            
+            stackLeading,
+            stackTrailing
         ])
+        
+        tableView.tableHeaderView = headerContainerView
+        
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+    
+    // MARK: - Layout Helper
+    private func layoutTableHeaderView() {
+        guard let header = tableView.tableHeaderView else { return }
+        
+        header.setNeedsLayout()
+        header.layoutIfNeeded()
+        
+        let size = header.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
+        
+        if header.frame.height != size.height {
+            header.frame.size.height = size.height
+            tableView.tableHeaderView = header
+        }
     }
 }

--- a/Spokast/Models/Episode.swift
+++ b/Spokast/Models/Episode.swift
@@ -1,0 +1,29 @@
+//
+//  Episode.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 19/12/25.
+//
+
+import Foundation
+
+struct Episode: Decodable, Identifiable {
+    var id: Int { trackId }
+    let trackId: Int
+    let trackName: String
+    let description: String?
+    let releaseDate: Date
+    let trackTimeMillis: Int?
+    let previewUrl: String?
+    let artworkUrl160: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case trackId
+        case trackName
+        case description
+        case releaseDate
+        case trackTimeMillis
+        case previewUrl
+        case artworkUrl160
+    }
+}

--- a/Spokast/Models/Podcast.swift
+++ b/Spokast/Models/Podcast.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 struct Podcast: Decodable {
+    let trackId: Int?
     let artistName: String
     let collectionName: String
     let artworkUrl100: String


### PR DESCRIPTION
### Summary
This PR enables the fetching and displaying of episodes on the Podcast Detail screen.

### Key Changes
* **Networking:** Adds `fetchEpisodes` to `APIService` using the iTunes `lookup` endpoint.
* **Model:** Adds `Episode` struct and updates `Podcast` to include `trackId`.
* **ViewModel:** Uses **Combine** to bind episode data to the View Controller.
* **UI:** Refactors `PodcastDetailView` to include a `UITableView` and a dynamic Header View.
* **Layout:** Fixes layout constraint conflicts in the header initialization.