### PR TITLE
feat(ui): Implement custom Episode cell design and refactor list logic

### DIFF
--- a/Spokast/Features/PodcastDetail/Views/Cells/EpisodeCell.swift
+++ b/Spokast/Features/PodcastDetail/Views/Cells/EpisodeCell.swift
@@ -1,0 +1,123 @@
+//
+//  EpisodeCell.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 20/12/25.
+//
+
+import Foundation
+import UIKit
+
+final class EpisodeCell: UITableViewCell {
+
+    static let reuseIdentifier = "EpisodeCell"
+    
+    // MARK: - UI Components
+    private let playIconContainer: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .systemPurple.withAlphaComponent(0.1)
+        view.layer.cornerRadius = 20
+        return view
+    }()
+    
+    private let playImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.image = UIImage(systemName: "play.fill")
+        imageView.tintColor = .systemPurple
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+    }()
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .systemFont(ofSize: 16, weight: .semibold)
+        label.textColor = .label
+        label.numberOfLines = 2
+        return label
+    }()
+    
+    private let descriptionLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = .systemFont(ofSize: 14, weight: .regular)
+        label.textColor = .secondaryLabel
+        label.numberOfLines = 1
+        return label
+    }()
+    
+    private lazy var textStackView: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [titleLabel, descriptionLabel])
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        stack.spacing = 4
+        stack.alignment = .leading
+        return stack
+    }()
+
+    // MARK: - Initialization
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupUI()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Configuration
+    func configure(with episode: Episode) {
+        titleLabel.text = episode.trackName
+        
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "MMM d, yyyy"
+        let dateString = dateFormatter.string(from: episode.releaseDate)
+        let durationText = formatDuration(millis: episode.trackTimeMillis)
+        
+        descriptionLabel.text = "\(dateString) • \(durationText)"
+    }
+    
+    // MARK: - Helpers
+    private func formatDuration(millis: Int?) -> String {
+        guard let millis = millis else { return "-- min" }
+        let seconds = millis / 1000
+        let minutes = seconds / 60
+        
+        if minutes > 60 {
+            let hours = minutes / 60
+            let remainingMinutes = minutes % 60
+            return "\(hours)h \(remainingMinutes)m"
+        } else {
+            return "\(minutes) min"
+        }
+    }
+
+    // MARK: - UI Setup
+    private func setupUI() {
+        backgroundColor = .systemBackground
+        selectionStyle = .default
+        contentView.addSubview(playIconContainer)
+        playIconContainer.addSubview(playImageView)
+        contentView.addSubview(textStackView)
+        
+        NSLayoutConstraint.activate([
+            playIconContainer.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            playIconContainer.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            playIconContainer.heightAnchor.constraint(equalToConstant: 40),
+            playIconContainer.widthAnchor.constraint(equalToConstant: 40),
+            
+            playImageView.centerXAnchor.constraint(equalTo: playIconContainer.centerXAnchor),
+            playImageView.centerYAnchor.constraint(equalTo: playIconContainer.centerYAnchor),
+            playImageView.heightAnchor.constraint(equalToConstant: 16),
+            playImageView.widthAnchor.constraint(equalToConstant: 16),
+            
+            textStackView.leadingAnchor.constraint(equalTo: playIconContainer.trailingAnchor, constant: 16),
+            textStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            textStackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 12),
+            textStackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -12)
+        ])
+    }
+}

--- a/Spokast/Features/PodcastDetail/Views/PodcastDetailView.swift
+++ b/Spokast/Features/PodcastDetail/Views/PodcastDetailView.swift
@@ -16,7 +16,7 @@ final class PodcastDetailView: UIView {
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.backgroundColor = .systemBackground
         tableView.separatorStyle = .singleLine
-        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "EpisodeCell")
+        tableView.register(EpisodeCell.self, forCellReuseIdentifier: EpisodeCell.reuseIdentifier)
         return tableView
     }()
     

--- a/Spokast/Features/PodcastDetail/Views/PodcastDetailViewController.swift
+++ b/Spokast/Features/PodcastDetail/Views/PodcastDetailViewController.swift
@@ -94,22 +94,12 @@ extension PodcastDetailViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "EpisodeCell", for: indexPath)
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: EpisodeCell.reuseIdentifier, for: indexPath) as? EpisodeCell else {
+            fatalError("Could not dequeue EpisodeCell")
+        }
+        
         let episode = viewModel.episodes[indexPath.row]
-        
-        var content = cell.defaultContentConfiguration()
-        content.text = episode.trackName
-        
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateStyle = .medium
-        let dateString = dateFormatter.string(from: episode.releaseDate)
-        
-        content.secondaryText = dateString
-        content.secondaryTextProperties.color = .secondaryLabel
-        
-        cell.contentConfiguration = content
-        cell.accessoryType = .disclosureIndicator
-        
+        cell.configure(with: episode)
         return cell
     }
 }


### PR DESCRIPTION
### Summary
This PR replaces the default `UITableViewCell` with a custom `EpisodeCell` to improve the UI/UX of the Episode List. It also refactors the data source logic to adhere to the Single Responsibility Principle.

### Key Changes
* **UI:** Created `EpisodeCell` with a custom layout including a circular play button, styled title, and metadata labels.
* **Logic:** Encapsulated date and duration formatting logic (ms to "MM min") within the cell configuration, removing this responsibility from the View Controller.
* **Architecture:** Refactored `PodcastDetailViewController` to delegate cell configuration to the cell itself.
* **Setup:** Updated `PodcastDetailView` to register the new custom cell class.

### How to Test
1. Open the app and navigate to a Podcast Detail screen.
2. Verify that the episode list now displays the custom design (Play icon, bold title).
3. Check if the release date and duration are formatted correctly (e.g., "Dec 19, 2025 • 45 min").