### PR TITLE
feat(audio): Implement basic audio playback integration

### DIFF
--- a/Spokast/Features/PodcastDetail/ViewModels/PodcastDetailViewModel.swift
+++ b/Spokast/Features/PodcastDetail/ViewModels/PodcastDetailViewModel.swift
@@ -13,14 +13,16 @@ final class PodcastDetailViewModel {
     // MARK: - Properties
     private let podcast: Podcast
     private let service: APIService
+    private let audioService: AudioPlayerProtocol
     
     @Published private(set) var episodes: [Episode] = []
     @Published private(set) var errorMessage: String?
     
     // MARK: - Initialization
-    init(podcast: Podcast, service: APIService) {
+    init(podcast: Podcast, service: APIService, audioService: AudioPlayerProtocol = AudioService.shared) {
         self.podcast = podcast
         self.service = service
+        self.audioService = audioService
     }
     
     // MARK: - Outputs
@@ -41,7 +43,7 @@ final class PodcastDetailViewModel {
         return podcast.primaryGenreName ?? "Podcast"
     }
     
-    // MARK: - Methods
+    // MARK: - API Methods
     func fetchEpisodes() {
         Task {
             do {
@@ -57,5 +59,18 @@ final class PodcastDetailViewModel {
                 }
             }
         }
+    }
+    
+    // MARK: - Audio Methods
+    func playEpisode(at index: Int) {
+        guard episodes.indices.contains(index) else { return }
+        let episode = episodes[index]
+        
+        guard let urlString = episode.previewUrl, let url = URL(string: urlString) else {
+            self.errorMessage = "Sorry, audio preview not available for this episode."
+            return
+        }
+        
+        audioService.play(url: url)
     }
 }

--- a/Spokast/Features/PodcastDetail/Views/PodcastDetailViewController.swift
+++ b/Spokast/Features/PodcastDetail/Views/PodcastDetailViewController.swift
@@ -37,6 +37,7 @@ final class PodcastDetailViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         customView?.tableView.dataSource = self
+        customView?.tableView.delegate = self
         setupConfiguration()
         setupBindings()
         viewModel.fetchEpisodes()
@@ -101,5 +102,14 @@ extension PodcastDetailViewController: UITableViewDataSource {
         let episode = viewModel.episodes[indexPath.row]
         cell.configure(with: episode)
         return cell
+    }
+}
+
+// MARK: - UITableViewDelegate
+extension PodcastDetailViewController: UITableViewDelegate {
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        viewModel.playEpisode(at: indexPath.row)
     }
 }

--- a/Spokast/Services/AudioService.swift
+++ b/Spokast/Services/AudioService.swift
@@ -1,0 +1,55 @@
+//
+//  AudioService.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 22/12/25.
+//
+
+import Foundation
+import AVFoundation
+
+protocol AudioPlayerProtocol {
+    func play(url: URL)
+    func pause()
+    func stop()
+}
+
+final class AudioService: AudioPlayerProtocol {
+    
+    // MARK: - Properties
+    static let shared = AudioService()
+    private var player: AVPlayer?
+    
+    // MARK: - Initialization
+    private init() {
+        setupAudioSession()
+    }
+    
+    // MARK: - Methods
+    func play(url: URL) {
+        let playerItem = AVPlayerItem(url: url)
+        player = AVPlayer(playerItem: playerItem)
+        player?.play()
+        print("▶️ AudioService: Playing \(url.lastPathComponent)")
+    }
+    
+    func pause() {
+        player?.pause()
+        print("⏸️ AudioService: Paused")
+    }
+    
+    func stop() {
+        player?.pause()
+        player = nil // Libera o recurso
+    }
+    
+    // MARK: - Private Setup
+    private func setupAudioSession() {
+        do {
+            try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
+            try AVAudioSession.sharedInstance().setActive(true)
+        } catch {
+            print("❌ AudioService Error: Failed to setup audio session: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
### Summary
This PR introduces the core audio playback functionality using `AVFoundation`. It allows users to tap on an episode in the list and listen to the audio preview.

### Key Changes
* **Service:** Created `AudioService` (singleton wrapper around `AVPlayer`) to handle audio sessions and playback commands.
* **Architecture:** Introduced `AudioPlayerProtocol` to decouple the service from the ViewModel, facilitating future unit testing.
* **ViewModel:** Updated `PodcastDetailViewModel` to inject the audio service and handle the `playEpisode(at:)` logic with URL validation.
* **UI/Interaction:** Implemented `UITableViewDelegate` in `PodcastDetailViewController` to capture user selection and trigger playback.

### Out of Scope
* **UI Feedback:** The play icon does not yet toggle between "Play" and "Pause" states. This visual feedback logic will be implemented in a subsequent PR to keep this one focused on the "Happy Path" of playback integration.

### How to Test
1. Launch the app and navigate to a Podcast Detail screen.
2. Ensure the device/simulator volume is up.
3. Tap on any episode in the list.
4. Verify that the audio starts playing.
5. Check Xcode logs for `▶️ AudioService: Playing...`.