### PR TITLE
feat(ui): Reactive Audio Player State Integration

### DIFF
--- a/Spokast/Features/PodcastDetail/ViewModels/PodcastDetailViewModel.swift
+++ b/Spokast/Features/PodcastDetail/ViewModels/PodcastDetailViewModel.swift
@@ -14,48 +14,49 @@ final class PodcastDetailViewModel {
     private let podcast: Podcast
     private let service: APIService
     private let audioService: AudioPlayerProtocol
+    private var cancellables = Set<AnyCancellable>()
     
     @Published private(set) var episodes: [Episode] = []
     @Published private(set) var errorMessage: String?
+    @Published private(set) var currentPlayingEpisodeId: Int? = nil
+    @Published private(set) var isPlayerPaused: Bool = false
     
     // MARK: - Initialization
-    init(podcast: Podcast, service: APIService, audioService: AudioPlayerProtocol = AudioService.shared) {
+    init(podcast: Podcast,
+         service: APIService,
+         audioService: AudioPlayerProtocol = AudioService.shared) {
         self.podcast = podcast
         self.service = service
         self.audioService = audioService
+        
+        setupAudioObserver()
     }
     
-    // MARK: - Outputs
-    var title: String {
-        return podcast.collectionName
-    }
-    
-    var artist: String {
-        return podcast.artistName
-    }
-    
+    var title: String { return podcast.collectionName }
+    var artist: String { return podcast.artistName }
+    var genre: String { return podcast.primaryGenreName ?? "Podcast" }
     var coverImageURL: URL? {
         let urlString = podcast.artworkUrl600 ?? podcast.artworkUrl100
         return URL(string: urlString)
     }
     
-    var genre: String {
-        return podcast.primaryGenreName ?? "Podcast"
-    }
-    
     // MARK: - API Methods
     func fetchEpisodes() {
+        guard let id = podcast.trackId else {
+            self.errorMessage = "Invalid Podcast ID"
+            return
+        }
+        
         Task {
             do {
-                let fetchedEpisodes = try await service.fetchEpisodes(for: podcast.trackId ?? 0)
-                
+                let fetchedEpisodes = try await service.fetchEpisodes(for: id)
                 await MainActor.run {
                     self.episodes = fetchedEpisodes
                 }
             } catch {
                 await MainActor.run {
-                    self.errorMessage = "Could not load episodes. Please try again."
-                    print("Error fetching episodes: \(error)")
+                    self.errorMessage = "Could not load episodes."
+                    print("Error: \(error)")
                 }
             }
         }
@@ -67,10 +68,40 @@ final class PodcastDetailViewModel {
         let episode = episodes[index]
         
         guard let urlString = episode.previewUrl, let url = URL(string: urlString) else {
-            self.errorMessage = "Sorry, audio preview not available for this episode."
+            self.errorMessage = "Audio preview not available."
             return
         }
-        
-        audioService.play(url: url)
+        audioService.toggle(url: url)
+    }
+    
+    // MARK: - Private Setup
+    private func setupAudioObserver() {
+        audioService.playerState
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                guard let self = self else { return }
+                self.handleAudioStateChange(state)
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func handleAudioStateChange(_ state: AudioPlayerState) {
+        switch state {
+        case .stopped:
+            self.currentPlayingEpisodeId = nil
+            self.isPlayerPaused = false
+            
+        case .playing(let url):
+            self.isPlayerPaused = false
+            if let episode = self.episodes.first(where: { $0.previewUrl == url.absoluteString }) {
+                self.currentPlayingEpisodeId = episode.trackId
+            }
+            
+        case .paused(let url):
+            self.isPlayerPaused = true
+            if let episode = self.episodes.first(where: { $0.previewUrl == url.absoluteString }) {
+                self.currentPlayingEpisodeId = episode.trackId
+            }
+        }
     }
 }

--- a/Spokast/Features/PodcastDetail/Views/Cells/EpisodeCell.swift
+++ b/Spokast/Features/PodcastDetail/Views/Cells/EpisodeCell.swift
@@ -78,6 +78,8 @@ final class EpisodeCell: UITableViewCell {
         let durationText = formatDuration(millis: episode.trackTimeMillis)
         
         descriptionLabel.text = "\(dateString) • \(durationText)"
+        playImageView.image = UIImage(systemName: "play.fill")
+        playIconContainer.backgroundColor = .systemPurple.withAlphaComponent(0.1)
     }
     
     // MARK: - Helpers
@@ -93,6 +95,16 @@ final class EpisodeCell: UITableViewCell {
         } else {
             return "\(minutes) min"
         }
+    }
+    
+    func updatePlaybackState(isPlaying: Bool) {
+        let iconName = isPlaying ? "pause.fill" : "play.fill"
+        
+        UIView.transition(with: playImageView, duration: 0.2, options: .transitionCrossDissolve) {
+            self.playImageView.image = UIImage(systemName: iconName)
+        }
+        
+        playIconContainer.backgroundColor = isPlaying ? .systemPurple.withAlphaComponent(0.3) : .systemPurple.withAlphaComponent(0.1)
     }
 
     // MARK: - UI Setup


### PR DESCRIPTION
### Summary
This PR completes the audio integration by adding visual feedback. The UI now reacts to the audio state, toggling between Play and Pause icons automatically.

### Key Changes
* **Combine:** Used `CurrentValueSubject` in `AudioService` and `CombineLatest` in `ViewController` to create a reactive data flow.
* **Performance:** Implemented `updateVisibleCells` to update only the relevant rows instead of calling `reloadData()`.
* **UX:** `EpisodeCell` now displays the correct icon based on the current playback state.
* **Logic:** Added a `toggle` method to handle Play/Pause/Resume logic centrally in the Service.

### How to Test
1. Play an episode. Verify the icon changes to Pause.
2. Tap the same episode again. Verify it pauses and the icon changes back to Play.
3. Tap a different episode. Verify the old one resets to Play and the new one becomes Pause.