### PR TITLE
feat(favorites): implement podcast subscription and favorites list navigation

### DIFF
--- a/Spokast/Core/Data/CoreDataService.swift
+++ b/Spokast/Core/Data/CoreDataService.swift
@@ -1,0 +1,55 @@
+//
+//  CoreDataService.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 25/12/25.
+//
+
+import Foundation
+import CoreData
+
+final class CoreDataService {
+    
+    static let shared = CoreDataService()
+    private let modelName = "Spokast"
+    
+    private init() {}
+    
+    // MARK: - Core Data Stack
+    lazy var persistentContainer: NSPersistentContainer = {
+        let container = NSPersistentContainer(name: modelName)
+        
+        container.loadPersistentStores { (storeDescription, error) in
+            if let error = error as NSError? {
+                fatalError("❌ Core Data Store failed to load: \(error), \(error.userInfo)")
+            }
+        }
+        
+        container.viewContext.automaticallyMergesChangesFromParent = true
+        container.viewContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+        
+        return container
+    }()
+    
+    // MARK: - Context Accessors
+    var viewContext: NSManagedObjectContext {
+        return persistentContainer.viewContext
+    }
+    
+    func performBackgroundTask(_ block: @escaping (NSManagedObjectContext) -> Void) {
+        persistentContainer.performBackgroundTask(block)
+    }
+    
+    // MARK: - Saving
+    func saveContext() {
+        let context = persistentContainer.viewContext
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                let nserror = error as NSError
+                print("❌ Error saving main context: \(nserror), \(nserror.userInfo)")
+            }
+        }
+    }
+}

--- a/Spokast/Core/Data/Repositories/FavoritesRepository.swift
+++ b/Spokast/Core/Data/Repositories/FavoritesRepository.swift
@@ -1,0 +1,77 @@
+//
+//  FavoritesRepository.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 25/12/25.
+//
+
+import Foundation
+import CoreData
+import Combine
+
+protocol FavoritesRepositoryProtocol {
+    func save(_ episode: Episode) throws
+    func remove(episodeId: Int64) throws
+    func isFavorite(episodeId: Int64) -> Bool
+    func fetchFavorites() -> [FavoriteEpisode]
+}
+
+final class FavoritesRepository: FavoritesRepositoryProtocol {
+    
+    private let context = CoreDataService.shared.viewContext
+    
+    // MARK: - Save
+    func save(_ episode: Episode) throws {
+        if isFavorite(episodeId: Int64(episode.trackId)) { return }
+        
+        let favorite = FavoriteEpisode(context: context)
+        favorite.id = Int64(episode.trackId)
+        favorite.title = episode.trackName
+        favorite.audioUrl = episode.previewUrl
+        favorite.createdAt = Date()
+        favorite.coverUrl = episode.artworkUrl160
+        favorite.author = episode.collectionName ?? "Unknown Podcast"
+        favorite.duration = episode.durationInSeconds
+        
+        try context.save()
+    }
+    
+    // MARK: - Delete
+    func remove(episodeId: Int64) throws {
+        let fetchRequest: NSFetchRequest<FavoriteEpisode> = FavoriteEpisode.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "id == %d", episodeId)
+        
+        if let result = try context.fetch(fetchRequest).first {
+            context.delete(result)
+            try context.save()
+        }
+    }
+    
+    // MARK: - Check
+    func isFavorite(episodeId: Int64) -> Bool {
+        let fetchRequest: NSFetchRequest<FavoriteEpisode> = FavoriteEpisode.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "id == %d", episodeId)
+        fetchRequest.fetchLimit = 1
+        
+        do {
+            let count = try context.count(for: fetchRequest)
+            return count > 0
+        } catch {
+            return false
+        }
+    }
+    
+    // MARK: - Fetch All
+    func fetchFavorites() -> [FavoriteEpisode] {
+        let fetchRequest: NSFetchRequest<FavoriteEpisode> = FavoriteEpisode.fetchRequest()
+        let sortDescriptor = NSSortDescriptor(key: "createdAt", ascending: false)
+        fetchRequest.sortDescriptors = [sortDescriptor]
+        
+        do {
+            return try context.fetch(fetchRequest)
+        } catch {
+            print("❌ Error fetching favorites: \(error)")
+            return []
+        }
+    }
+}

--- a/Spokast/Core/Data/Spokast.xcdatamodeld/Spokast.xcdatamodel/contents
+++ b/Spokast/Core/Data/Spokast.xcdatamodeld/Spokast.xcdatamodel/contents
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24411" systemVersion="25B78" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+    <entity name="FavoriteEpisode" representedClassName="FavoriteEpisode" syncable="YES" codeGenerationType="class">
+        <attribute name="audioUrl" optional="YES" attributeType="String"/>
+        <attribute name="author" optional="YES" attributeType="String"/>
+        <attribute name="coverUrl" optional="YES" attributeType="String"/>
+        <attribute name="createdAt" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="duration" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="id" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="title" attributeType="String"/>
+    </entity>
+</model>

--- a/Spokast/Core/Data/Spokast.xcdatamodeld/Spokast.xcdatamodel/contents
+++ b/Spokast/Core/Data/Spokast.xcdatamodeld/Spokast.xcdatamodel/contents
@@ -9,4 +9,11 @@
         <attribute name="id" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="title" attributeType="String"/>
     </entity>
+    <entity name="FavoritePodcast" representedClassName="FavoritePodcast" syncable="YES" codeGenerationType="class">
+        <attribute name="author" optional="YES" attributeType="String"/>
+        <attribute name="coverUrl" attributeType="String"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="title" attributeType="String"/>
+    </entity>
 </model>

--- a/Spokast/Features/Favorites/Cells/FavoriteCell.swift
+++ b/Spokast/Features/Favorites/Cells/FavoriteCell.swift
@@ -1,0 +1,136 @@
+//
+//  FavoriteCell.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 27/12/25.
+//
+
+import Foundation
+import UIKit
+import Kingfisher
+
+final class FavoriteCell: UITableViewCell {
+    
+    // MARK: - Identifier
+    static let reuseIdentifier = "FavoriteCell"
+    
+    // MARK: - UI Components
+    private let coverImageView: UIImageView = {
+        let iv = UIImageView()
+        iv.contentMode = .scaleAspectFill
+        iv.layer.cornerRadius = 8
+        iv.clipsToBounds = true
+        iv.backgroundColor = .secondarySystemBackground
+        iv.translatesAutoresizingMaskIntoConstraints = false
+        return iv
+    }()
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 16, weight: .semibold)
+        label.textColor = .label
+        label.numberOfLines = 2
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private let authorLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 14, weight: .regular)
+        label.textColor = .secondaryLabel
+        label.numberOfLines = 1
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private lazy var textStackView: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [titleLabel, authorLabel])
+        stack.axis = .vertical
+        stack.spacing = 4
+        stack.alignment = .leading
+        stack.distribution = .fill
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        return stack
+    }()
+    
+    private let chevronImageView: UIImageView = {
+        let iv = UIImageView()
+        iv.image = UIImage(systemName: "chevron.right")
+        iv.tintColor = .tertiaryLabel
+        iv.contentMode = .scaleAspectFit
+        iv.translatesAutoresizingMaskIntoConstraints = false
+        return iv
+    }()
+    
+    // MARK: - Init
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setupLayout()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Lifecycle
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        coverImageView.kf.cancelDownloadTask()
+        coverImageView.image = nil
+        titleLabel.text = nil
+        authorLabel.text = nil
+    }
+    
+    // MARK: - Configuration
+    func configure(with podcast: FavoritePodcast) {
+        titleLabel.text = podcast.title
+        authorLabel.text = podcast.author
+        
+        if let urlString = podcast.coverUrl, let url = URL(string: urlString) {
+            
+            let processor = DownsamplingImageProcessor(size: CGSize(width: 60, height: 60))
+            
+            coverImageView.kf.setImage(
+                with: url,
+                placeholder: UIImage(systemName: "mic.circle"),
+                options: [
+                    .processor(processor),
+                    .scaleFactor(UIScreen.main.scale),
+                    .transition(.fade(0.3)),
+                    .cacheOriginalImage
+                ]
+            )
+        } else {
+            coverImageView.image = UIImage(systemName: "mic.circle")
+        }
+    }
+    
+    // MARK: - Layout
+    private func setupLayout() {
+        backgroundColor = .systemBackground
+        selectionStyle = .default
+        
+        contentView.addSubview(coverImageView)
+        contentView.addSubview(textStackView)
+        contentView.addSubview(chevronImageView)
+        
+        NSLayoutConstraint.activate([
+            coverImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            coverImageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            coverImageView.heightAnchor.constraint(equalToConstant: 60),
+            coverImageView.widthAnchor.constraint(equalToConstant: 60),
+            
+            chevronImageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            chevronImageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            chevronImageView.widthAnchor.constraint(equalToConstant: 12),
+            chevronImageView.heightAnchor.constraint(equalToConstant: 20),
+            
+            textStackView.leadingAnchor.constraint(equalTo: coverImageView.trailingAnchor, constant: 16),
+            textStackView.trailingAnchor.constraint(equalTo: chevronImageView.leadingAnchor, constant: -12),
+            textStackView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            
+            contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 84)
+        ])
+    }
+}

--- a/Spokast/Features/Favorites/Coordinator/FavoritesCoordinator.swift
+++ b/Spokast/Features/Favorites/Coordinator/FavoritesCoordinator.swift
@@ -16,7 +16,27 @@ final class FavoritesCoordinator: Coordinator {
     }
     
     func start() {
-        let viewController = FavoritesViewController()
+        let repository = FavoritesRepository()
+        let viewModel = FavoritesViewModel(repository: repository)
+        let viewController = FavoritesViewController(viewModel: viewModel)
+        viewController.coordinator = self
         navigationController.pushViewController(viewController, animated: false)
     }
+}
+
+extension FavoritesCoordinator: PodcastSelectionDelegate {
+    func didSelectPodcast(_ podcast: Podcast) {
+            let service = APIService()
+            let favoritesRepository = FavoritesRepository()
+            
+            let detailViewModel = PodcastDetailViewModel(
+                podcast: podcast,
+                service: service,
+                favoritesRepository: favoritesRepository
+            )
+            
+            let detailVC = PodcastDetailViewController(viewModel: detailViewModel)
+            
+            navigationController.pushViewController(detailVC, animated: true)
+        }
 }

--- a/Spokast/Features/Favorites/ViewModels/FavoritesViewModel.swift
+++ b/Spokast/Features/Favorites/ViewModels/FavoritesViewModel.swift
@@ -1,0 +1,74 @@
+//
+//  FavoritesViewModel.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 26/12/25.
+//
+
+import Foundation
+import Combine
+
+enum FavoritesViewState {
+    case loading
+    case empty
+    case content
+}
+
+final class FavoritesViewModel {
+    
+    // MARK: - Dependencies
+    private let repository: FavoritesRepositoryProtocol
+    
+    // MARK: - Properties
+    private var cancellables = Set<AnyCancellable>()
+    
+    // MARK: - Outputs
+    @Published private(set) var podcasts: [FavoritePodcast] = []
+    @Published private(set) var viewState: FavoritesViewState = .loading
+    
+    // MARK: - Initialization
+    init(repository: FavoritesRepositoryProtocol) {
+        self.repository = repository
+    }
+    
+    // MARK: - Methods
+    func loadFavorites() {
+        self.viewState = .loading
+    
+        let items = repository.fetchFollowedPodcasts()
+        
+        if items.isEmpty {
+            self.podcasts = []
+            self.viewState = .empty
+        } else {
+            self.podcasts = items
+            self.viewState = .content
+        }
+    }
+    
+    func removePodcast(at index: Int) {
+        guard podcasts.indices.contains(index) else { return }
+        let podcastToRemove = podcasts[index]
+        
+        let dummyEpisode = Episode(
+            trackId: 0,
+            trackName: "",
+            description: nil,
+            releaseDate: Date(),
+            trackTimeMillis: 0,
+            previewUrl: nil,
+            artworkUrl160: nil,
+            collectionName: podcastToRemove.title,
+            collectionId: Int(podcastToRemove.id),
+            artworkUrl600: podcastToRemove.coverUrl
+        )
+        
+        do {
+            _ = try repository.togglePodcastSubscription(for: dummyEpisode)
+
+            loadFavorites()
+        } catch {
+            print("❌ Error removing favorite: \(error)")
+        }
+    }
+}

--- a/Spokast/Features/Favorites/Views/FavoritesView.swift
+++ b/Spokast/Features/Favorites/Views/FavoritesView.swift
@@ -1,0 +1,98 @@
+//
+//  FavoritesView.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 27/12/25.
+//
+
+import Foundation
+import UIKit
+
+final class FavoritesView: UIView {
+    
+    // MARK: - UI Components
+    lazy var tableView: UITableView = {
+        let table = UITableView()
+        table.backgroundColor = .systemBackground
+        table.separatorStyle = .singleLine
+        table.register(FavoriteCell.self, forCellReuseIdentifier: FavoriteCell.reuseIdentifier)
+        table.tableFooterView = UIView()
+        table.translatesAutoresizingMaskIntoConstraints = false
+        return table
+    }()
+    
+    private let activityIndicator: UIActivityIndicatorView = {
+        let spinner = UIActivityIndicatorView(style: .large)
+        spinner.color = .systemPurple
+        spinner.hidesWhenStopped = true
+        spinner.translatesAutoresizingMaskIntoConstraints = false
+        return spinner
+    }()
+    
+    private let emptyLabel: UILabel = {
+        let label = UILabel()
+        label.text = "You haven't followed any podcasts yet.\nGo explore!"
+        label.textColor = .secondaryLabel
+        label.textAlignment = .center
+        label.numberOfLines = 0
+        label.font = .systemFont(ofSize: 16, weight: .medium)
+        label.isHidden = true
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    // MARK: - Init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupLayout()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Public Methods
+    func updateState(_ state: FavoritesViewState) {
+        switch state {
+        case .loading:
+            activityIndicator.startAnimating()
+            tableView.isHidden = true
+            emptyLabel.isHidden = true
+            
+        case .empty:
+            activityIndicator.stopAnimating()
+            tableView.isHidden = true
+            emptyLabel.isHidden = false
+            
+        case .content:
+            activityIndicator.stopAnimating()
+            tableView.isHidden = false
+            emptyLabel.isHidden = true
+        }
+    }
+    
+    // MARK: - Layout
+    private func setupLayout() {
+        backgroundColor = .systemBackground
+        
+        addSubview(tableView)
+        addSubview(emptyLabel)
+        addSubview(activityIndicator)
+        
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            
+            emptyLabel.centerXAnchor.constraint(equalTo: centerXAnchor),
+            emptyLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+            emptyLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 32),
+            emptyLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -32),
+            
+            activityIndicator.centerXAnchor.constraint(equalTo: centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: centerYAnchor)
+        ])
+    }
+}

--- a/Spokast/Features/Favorites/Views/FavoritesViewController.swift
+++ b/Spokast/Features/Favorites/Views/FavoritesViewController.swift
@@ -7,24 +7,116 @@
 
 import Foundation
 import UIKit
+import Combine
+import Kingfisher
+
+protocol PodcastSelectionDelegate: AnyObject {
+    func didSelectPodcast(_ podcast: Podcast)
+}
 
 final class FavoritesViewController: UIViewController {
     
+    // MARK: - Properties
+    private let viewModel: FavoritesViewModel
+    private var cancellables = Set<AnyCancellable>()
+    weak var coordinator: PodcastSelectionDelegate?
+    
+    private var customView: FavoritesView {
+        return self.view as! FavoritesView
+    }
+    
+    // MARK: - Init
+    init(viewModel: FavoritesViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+        self.title = "Favorites"
+        self.tabBarItem = UITabBarItem(tabBarSystemItem: .favorites, tag: 1)
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Lifecycle
+    override func loadView() {
+        self.view = FavoritesView()
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .systemBackground
-        title = "Favorites"
+        customView.tableView.dataSource = self
+        customView.tableView.delegate = self
+        setupBindings()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        viewModel.loadFavorites()
+    }
+    
+    // MARK: - Bindings
+    private func setupBindings() {
+        viewModel.$viewState
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                self?.customView.updateState(state)
+            }
+            .store(in: &cancellables)
         
-        let label = UILabel()
-        label.text = "Comming Soon"
-        label.font = .systemFont(ofSize: 20, weight: .bold)
-        label.textColor = .secondaryLabel
-        label.translatesAutoresizingMaskIntoConstraints = false
+        viewModel.$podcasts
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.customView.tableView.reloadData()
+            }
+            .store(in: &cancellables)
+    }
+}
+
+// MARK: - UITableViewDataSource
+extension FavoritesViewController: UITableViewDataSource {
+    
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return viewModel.podcasts.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: FavoriteCell.reuseIdentifier, for: indexPath) as? FavoriteCell else {
+                fatalError("Could not dequeue FavoriteCell")
+            }
+            
+            let podcast = viewModel.podcasts[indexPath.row]
+            cell.configure(with: podcast)
+            
+            return cell
+        }
+}
+
+// MARK: - UITableViewDelegate
+extension FavoritesViewController: UITableViewDelegate {
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
         
-        view.addSubview(label)
-        NSLayoutConstraint.activate([
-            label.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            label.centerYAnchor.constraint(equalTo: view.centerYAnchor)
-        ])
+        let favorite = viewModel.podcasts[indexPath.row]
+        
+        let podcastModel = Podcast(
+            trackId: Int(favorite.id),
+            artistName: favorite.author ?? "Unknown",
+            collectionName: favorite.title ?? "Unknown",
+            artworkUrl100: favorite.coverUrl ?? "",
+            feedUrl: nil,
+            artworkUrl600: favorite.coverUrl,
+            primaryGenreName: "Podcast"
+        )
+        
+        coordinator?.didSelectPodcast(podcastModel)
+    }
+    
+    func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+        if editingStyle == .delete {
+            viewModel.removePodcast(at: indexPath.row)
+    
+        }
     }
 }

--- a/Spokast/Features/Home/HomeCoordinator.swift
+++ b/Spokast/Features/Home/HomeCoordinator.swift
@@ -52,7 +52,8 @@ final class HomeCoordinator: Coordinator {
 extension HomeCoordinator: HomeViewControllerDelegate {
     func didSelectPodcast(_ podcast: Podcast) {
         let service = APIService()
-        let detailViewModel = PodcastDetailViewModel(podcast: podcast, service: service)
+        let favoritesRepository = FavoritesRepository()
+        let detailViewModel = PodcastDetailViewModel(podcast: podcast, service: service, favoritesRepository: favoritesRepository)
         let detailViewController = PodcastDetailViewController(viewModel: detailViewModel)
         detailViewController.coordinator = self
         navigationController.pushViewController(detailViewController, animated: true)

--- a/Spokast/Features/Home/HomeCoordinator.swift
+++ b/Spokast/Features/Home/HomeCoordinator.swift
@@ -28,9 +28,12 @@ final class HomeCoordinator: Coordinator {
     
     // MARK: - Navigation to Player
     func presentPlayer(for episode: Episode, podcastImageURL: URL?) {
+        
+        let favoritesRepository = FavoritesRepository()
         let playerViewModel = PlayerViewModel(
             episode: episode,
-            podcastImageURL: podcastImageURL
+            podcastImageURL: podcastImageURL,
+            favoritesRepository: favoritesRepository
         )
         
         let playerViewController = PlayerViewController(viewModel: playerViewModel)

--- a/Spokast/Features/Player/ViewModels/PlayerViewModel.swift
+++ b/Spokast/Features/Player/ViewModels/PlayerViewModel.swift
@@ -71,22 +71,17 @@ final class PlayerViewModel {
     }
     
     func didTapFavorite() {
-        do {
-            if isFavorite {
-                try favoritesRepository.remove(episodeId: Int64(episode.trackId))
-                isFavorite = false
-            } else {
-                try favoritesRepository.save(episode)
-                isFavorite = true
+            do {
+                let newState = try favoritesRepository.togglePodcastSubscription(for: episode)
+                isFavorite = newState
+            } catch {
+                print("❌ Error toggling subscription: \(error)")
             }
-        } catch {
-            print("❌ Error toggling favorite: \(error)")
         }
-    }
     
     // MARK: - Private Setup
     private func checkFavoriteStatus() {
-        isFavorite = favoritesRepository.isFavorite(episodeId: Int64(episode.trackId))
+        isFavorite = favoritesRepository.isPodcastFollowed(id: episode.collectionId)
     }
     
     private func setupBindings() {

--- a/Spokast/Features/PodcastDetail/Views/PodcastDetailView.swift
+++ b/Spokast/Features/PodcastDetail/Views/PodcastDetailView.swift
@@ -17,6 +17,7 @@ final class PodcastDetailView: UIView {
         tableView.backgroundColor = .systemBackground
         tableView.separatorStyle = .singleLine
         tableView.register(EpisodeCell.self, forCellReuseIdentifier: EpisodeCell.reuseIdentifier)
+        tableView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 20, right: 0)
         return tableView
     }()
     
@@ -50,6 +51,29 @@ final class PodcastDetailView: UIView {
         return label
     }()
     
+    lazy var subscribeButton: UIButton = {
+        var config = UIButton.Configuration.filled()
+        config.cornerStyle = .capsule
+        config.baseBackgroundColor = .systemPurple
+        config.baseForegroundColor = .white
+        config.title = "SUBSCRIBE"
+        config.contentInsets = NSDirectionalEdgeInsets(top: 6, leading: 16, bottom: 6, trailing: 16)
+        
+        let button = UIButton(configuration: config)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.heightAnchor.constraint(equalToConstant: 34).isActive = true
+        return button
+    }()
+    
+    private lazy var artistStackView: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [artistLabel, subscribeButton])
+        stack.axis = .horizontal
+        stack.spacing = 12
+        stack.alignment = .center
+        stack.distribution = .fill
+        return stack
+    }()
+    
     private let genreLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -60,7 +84,7 @@ final class PodcastDetailView: UIView {
     }()
 
     private lazy var headerStackView: UIStackView = {
-        let stack = UIStackView(arrangedSubviews: [imageView, titleLabel, artistLabel, genreLabel])
+        let stack = UIStackView(arrangedSubviews: [imageView, titleLabel, artistStackView, genreLabel])
         stack.translatesAutoresizingMaskIntoConstraints = false
         stack.axis = .vertical
         stack.spacing = 16
@@ -92,16 +116,39 @@ final class PodcastDetailView: UIView {
         genreLabel.text = viewModel.genre.uppercased()
         layoutTableHeaderView()
     }
+    
+    func updateSubscribeButton(isSubscribed: Bool) {
+        var config = subscribeButton.configuration
+        
+        if isSubscribed {
+            config?.baseBackgroundColor = .systemGray5
+            config?.baseForegroundColor = .secondaryLabel
+            config?.title = "SUBSCRIBED"
+            config?.image = UIImage(systemName: "checkmark")
+            config?.imagePadding = 6
+            config?.imagePlacement = .leading
+        } else {
+            config?.baseBackgroundColor = .systemPurple
+            config?.baseForegroundColor = .white
+            config?.title = "SUBSCRIBE"
+            config?.image = nil
+        }
+        
+        UIView.transition(with: subscribeButton, duration: 0.2, options: .transitionCrossDissolve) {
+            self.subscribeButton.configuration = config
+        }
+    }
 
     // MARK: - UI Setup
     private func setupUI() {
         backgroundColor = .systemBackground
         addSubview(tableView)
+        
         headerContainerView.addSubview(headerStackView)
         
         let stackLeading = headerStackView.leadingAnchor.constraint(equalTo: headerContainerView.leadingAnchor, constant: 24)
         let stackTrailing = headerStackView.trailingAnchor.constraint(equalTo: headerContainerView.trailingAnchor, constant: -24)
-      
+        
         stackLeading.priority = UILayoutPriority(999)
         stackTrailing.priority = UILayoutPriority(999)
         
@@ -111,13 +158,14 @@ final class PodcastDetailView: UIView {
             
             headerStackView.topAnchor.constraint(equalTo: headerContainerView.topAnchor, constant: 32),
             headerStackView.bottomAnchor.constraint(equalTo: headerContainerView.bottomAnchor, constant: -32),
+            headerStackView.centerXAnchor.constraint(equalTo: headerContainerView.centerXAnchor),
             
             stackLeading,
             stackTrailing
         ])
         
         tableView.tableHeaderView = headerContainerView
-        
+
         NSLayoutConstraint.activate([
             tableView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
             tableView.leadingAnchor.constraint(equalTo: leadingAnchor),

--- a/Spokast/Models/Episode.swift
+++ b/Spokast/Models/Episode.swift
@@ -17,6 +17,8 @@ struct Episode: Decodable, Identifiable {
     let previewUrl: String?
     let artworkUrl160: String?
     let collectionName: String?
+    let collectionId: Int
+    let artworkUrl600: String?
     
     var durationInSeconds: Double {
         guard let millis = trackTimeMillis else { return 0.0 }
@@ -32,5 +34,7 @@ struct Episode: Decodable, Identifiable {
         case previewUrl
         case artworkUrl160
         case collectionName
+        case collectionId
+        case artworkUrl600
     }
 }

--- a/Spokast/Models/Episode.swift
+++ b/Spokast/Models/Episode.swift
@@ -16,6 +16,12 @@ struct Episode: Decodable, Identifiable {
     let trackTimeMillis: Int?
     let previewUrl: String?
     let artworkUrl160: String?
+    let collectionName: String?
+    
+    var durationInSeconds: Double {
+        guard let millis = trackTimeMillis else { return 0.0 }
+        return Double(millis) / 1000.0
+    }
     
     enum CodingKeys: String, CodingKey {
         case trackId
@@ -25,5 +31,6 @@ struct Episode: Decodable, Identifiable {
         case trackTimeMillis
         case previewUrl
         case artworkUrl160
+        case collectionName
     }
 }


### PR DESCRIPTION
Summary
This PR implements the end-to-end "Favorites" feature. It allows users to subscribe to podcasts from the Detail screen, view a persisted list of followed podcasts in the Favorites tab, and navigate back to the details of a saved podcast. It also includes UI optimizations for image loading and architectural improvements in Dependency Injection.

Key Changes
Podcast Detail:

Added subscribeButton to PodcastDetailView with dynamic styling (capsule style).

Updated PodcastDetailViewModel to handle subscription toggling via FavoritesRepository.

Refactored PodcastDetailViewController to bind the subscription state.

Favorites Feature:

Created FavoritesViewController, FavoritesViewModel, and FavoritesView.

Implemented FavoriteCell with Kingfisher Downsampling processor for optimized memory usage during scrolling.

Added Swipe-to-Delete functionality to remove favorites.

Handled View States: Loading, Empty, and Content.

Architecture & Navigation:

Implemented FavoritesCoordinator conforming to PodcastSelectionDelegate to handle navigation flow.

Fixed Dependency Injection in HomeCoordinator and FavoritesCoordinator (removed default values in ViewModels).

Ensured proper coordinator retention in AppCoordinator.

Technical Details
Persistence: Uses Core Data (via FavoritesRepository) to store and fetch podcast data.

UI: 100% Programmatic View Code using Auto Layout.

Reactive: Uses Combine for bindings between ViewModels and ViewControllers.

Images: Optimized rendering using DownsamplingImageProcessor to maintain 60fps scrolling performance.

Checklist
[x] Subscribe button updates state correctly (Purple/Gray).

[x] Favorites list loads from Core Data.

[x] Empty state is shown when no favorites exist.

[x] Swipe to delete works and updates the UI immediately.

[x] Clicking a favorite navigates to the correct Podcast Detail screen.

[x] Dependency Injection applied to all new modules.