### PR TITLE
feat(home): redesign home screen with compositional layout and multi-category support

### DIFF
--- a/Spokast/Features/Home/Views/Components/HomeSectionHeader.swift
+++ b/Spokast/Features/Home/Views/Components/HomeSectionHeader.swift
@@ -1,0 +1,48 @@
+//
+//  HomeSectionHeader.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 28/12/25.
+//
+
+import Foundation
+import UIKit
+
+final class HomeSectionHeader: UICollectionReusableView {
+    
+    static let reuseIdentifier = "HomeSectionHeader"
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.textColor = .label
+        label.font = .systemFont(ofSize: 22, weight: .bold)
+        label.numberOfLines = 1
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupLayout()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func configure(with title: String) {
+        titleLabel.text = title
+    }
+    
+    private func setupLayout() {
+        addSubview(titleLabel)
+        
+        NSLayoutConstraint.activate([
+            titleLabel.leadingAnchor.constraint(equalTo: leadingAnchor),
+            titleLabel.trailingAnchor.constraint(equalTo: trailingAnchor),
+            titleLabel.topAnchor.constraint(equalTo: topAnchor),
+            titleLabel.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+    }
+}

--- a/Spokast/Features/Home/Views/FeaturedPodcastCell.swift
+++ b/Spokast/Features/Home/Views/FeaturedPodcastCell.swift
@@ -1,0 +1,111 @@
+//
+//  FeaturedPodcastCell.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 28/12/25.
+//
+
+import Foundation
+import UIKit
+import Kingfisher
+
+final class FeaturedPodcastCell: UICollectionViewCell {
+    
+    static let reuseIdentifier = "FeaturedPodcastCell"
+    
+    // MARK: - UI Components
+    private let imageView: UIImageView = {
+        let iv = UIImageView()
+        iv.contentMode = .scaleAspectFill
+        iv.layer.cornerRadius = 12
+        iv.clipsToBounds = true
+        iv.backgroundColor = .secondarySystemBackground
+        iv.translatesAutoresizingMaskIntoConstraints = false
+        return iv
+    }()
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 14, weight: .semibold)
+        label.textColor = .label
+        label.numberOfLines = 1
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private let authorLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 12, weight: .regular)
+        label.textColor = .secondaryLabel
+        label.numberOfLines = 1
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    // MARK: - Init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupLayout()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        imageView.kf.cancelDownloadTask()
+        imageView.image = nil
+        titleLabel.text = nil
+        authorLabel.text = nil
+    }
+    
+    // MARK: - Configuration
+    func configure(with podcast: Podcast) {
+        titleLabel.text = podcast.collectionName
+        authorLabel.text = podcast.artistName
+        
+        let urlString = podcast.artworkUrl600 ?? podcast.artworkUrl100
+        
+        if let url = URL(string: urlString) {
+            
+            let processor = DownsamplingImageProcessor(size: CGSize(width: 140, height: 140))
+            
+            imageView.kf.setImage(
+                with: url,
+                placeholder: UIImage(systemName: "mic.circle"),
+                options: [
+                    .processor(processor),
+                    .scaleFactor(UIScreen.main.scale),
+                    .transition(.fade(0.3)),
+                    .cacheOriginalImage
+                ]
+            )
+        } else {
+            imageView.image = UIImage(systemName: "mic.circle")
+        }
+    }
+    
+    // MARK: - Layout
+    private func setupLayout() {
+        contentView.addSubview(imageView)
+        contentView.addSubview(titleLabel)
+        contentView.addSubview(authorLabel)
+        
+        NSLayoutConstraint.activate([
+            imageView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            imageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            imageView.heightAnchor.constraint(equalTo: contentView.widthAnchor),
+            
+            titleLabel.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: 8),
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            
+            authorLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 2),
+            authorLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            authorLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+        ])
+    }
+}

--- a/Spokast/Features/Home/Views/HomeView.swift
+++ b/Spokast/Features/Home/Views/HomeView.swift
@@ -9,47 +9,90 @@ import Foundation
 import UIKit
 
 final class HomeView: UIView {
-
+    
     // MARK: - UI Components
-    let podcastsTableView: UITableView = {
-        let tableView = UITableView()
-        tableView.translatesAutoresizingMaskIntoConstraints = false
-        tableView.register(PodcastCell.self, forCellReuseIdentifier: PodcastCell.reuseIdentifier)
-        return tableView
+    lazy var collectionView: UICollectionView = {
+        let layout = createCompositionalLayout()
+        let cv = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        cv.backgroundColor = .systemBackground
+        cv.register(FeaturedPodcastCell.self, forCellWithReuseIdentifier: FeaturedPodcastCell.reuseIdentifier)
+        cv.register(HomeSectionHeader.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: HomeSectionHeader.reuseIdentifier)
+        cv.translatesAutoresizingMaskIntoConstraints = false
+        return cv
     }()
-
-    // MARK: - Initialization
+    
+    let activityIndicator: UIActivityIndicatorView = {
+        let spinner = UIActivityIndicatorView(style: .large)
+        spinner.hidesWhenStopped = true
+        spinner.translatesAutoresizingMaskIntoConstraints = false
+        return spinner
+    }()
+    
+    // MARK: - Init
     override init(frame: CGRect) {
         super.init(frame: frame)
-        setupLayout();
+        setupLayout()
     }
-
+    
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
-    // MARK: - Private Methods
+    
+    // MARK: - Compositional Layout
+    private func createCompositionalLayout() -> UICollectionViewLayout {
+        return UICollectionViewCompositionalLayout { (sectionIndex, layoutEnvironment) -> NSCollectionLayoutSection? in
+            
+            let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                                  heightDimension: .fractionalHeight(1.0))
+            let item = NSCollectionLayoutItem(layoutSize: itemSize)
+            let groupSize = NSCollectionLayoutSize(widthDimension: .absolute(160),
+                                                   heightDimension: .absolute(220))
+            let group = NSCollectionLayoutGroup.horizontal(layoutSize: groupSize, subitems: [item])
+            let section = NSCollectionLayoutSection(group: group)
+            section.orthogonalScrollingBehavior = .continuous
+            section.interGroupSpacing = 16
+            section.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 16, bottom: 30, trailing: 16)
+            
+            let headerSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                                    heightDimension: .absolute(40))
+            let header = NSCollectionLayoutBoundarySupplementaryItem(
+                layoutSize: headerSize,
+                elementKind: UICollectionView.elementKindSectionHeader,
+                alignment: .top
+            )
+            section.boundarySupplementaryItems = [header]
+            
+            return section
+        }
+    }
+    
+    // MARK: - View Code Setup
     private func setupLayout() {
-        setupHierarchy()
-        setupConstraints()
-        setupConfigurations()
-    }
-
-    private func setupHierarchy() {
-        addSubview(podcastsTableView)
-    }
-
-    private func setupConstraints() {
+        backgroundColor = .systemBackground
+        
+        addSubview(collectionView)
+        addSubview(activityIndicator)
+        
         NSLayoutConstraint.activate([
-            podcastsTableView.topAnchor.constraint(equalTo: self.topAnchor),
-            podcastsTableView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-            podcastsTableView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-            podcastsTableView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+            collectionView.topAnchor.constraint(equalTo: topAnchor),
+            collectionView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            collectionView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            
+            activityIndicator.centerXAnchor.constraint(equalTo: centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: centerYAnchor)
         ])
     }
-
-    private func setupConfigurations() {
-        backgroundColor = .systemBackground
+    
+    // MARK: - Public Methods
+    func showLoading(_ isLoading: Bool) {
+        if isLoading {
+            activityIndicator.startAnimating()
+            collectionView.isHidden = true
+        } else {
+            activityIndicator.stopAnimating()
+            collectionView.isHidden = false
+        }
     }
 }

--- a/Spokast/Services/APIServiceProtocol.swift
+++ b/Spokast/Services/APIServiceProtocol.swift
@@ -9,10 +9,12 @@ import Foundation
 
 enum APIError: Error {
     case invalidURL
+    case invalidResponse
     case requestFailed(Error)
     case decodingError(Error)
 }
 
 protocol APIServiceProtocol {
-    func fetchPodcasts(searchTerm: String) async throws -> [Podcast]
+    func fetchPodcasts(searchTerm: String, limit: Int) async throws -> [Podcast]
+    func fetchEpisodes(for podcastId: Int) async throws -> [Episode]
 }


### PR DESCRIPTION
Summary
This PR overhauls the Home Screen, transitioning from a simple vertical list (UITableView) to a modern, multi-section showcase (UICollectionView with Compositional Layout). It enables the app to display "Trending", "Tech", and "Comedy" podcasts simultaneously using parallel data fetching.

Key Changes
UI & UX:

Replaced HomeViewController's TableView with a Compositional Layout CollectionView.

Implemented orthogonal scrolling (horizontal carousels) for distinct podcast sections.

Added FeaturedPodcastCell with optimized image rendering (downsampling).

Added HomeSectionHeader to display category titles.

Networking & Data:

Updated APIService to support a limit parameter, optimizing payload size for sectioned requests.

Refactored APIServiceError to unify error handling across the network layer.

Architecture:

Refactored HomeViewModel to use Structured Concurrency (async let). Now fetches 3 distinct categories in parallel, reducing total load time.

Introduced HomeSection model to manage sectional data state.

Replaced Delegate pattern with Combine for reactive state updates ($sections, $state).

Technical Details
Performance: Images are now downsampled to the exact cell size (140x140) using Kingfisher, significantly reducing memory footprint during scrolling.

Concurrency: The Home screen makes concurrent requests to the iTunes API. Wait time is determined by the slowest request, not the sum of all requests.

Layout: Uses UICollectionViewCompositionalLayout to define groups, items, and sections declaratively.

Checklist
[x] Home screen displays 3 distinct sections (Trending, Tech, Comedy).

[x] Horizontal scrolling works smoothly within each section.

[x] Clicking a podcast navigates correctly to the Detail screen.

[x] Parallel fetching works without race conditions.

[x] Loading and Error states are handled gracefully.