### PR TITLE
feat(search): implement search tab with debounced API integration

### DIFF
--- a/Spokast/Application/AppCoordinator.swift
+++ b/Spokast/Application/AppCoordinator.swift
@@ -40,7 +40,12 @@ final class AppCoordinator: Coordinator {
         childCoordinators.append(favCoordinator)
         favCoordinator.start()
         
-        tabBarController.viewControllers = [homeNavController, favNavController]
+        let searchNav = UINavigationController()
+        let searchCoordinator = SearchCoordinator(navigationController: searchNav)
+        childCoordinators.append(searchCoordinator)
+        searchCoordinator.start()
+        
+        tabBarController.viewControllers = [homeNavController, favNavController, searchNav]
         tabBarController.tabBar.tintColor = .systemPurple
         tabBarController.tabBar.backgroundColor = .systemBackground
         window.rootViewController = tabBarController

--- a/Spokast/Features/Search/Coordinator/SearchCoordinator.swift
+++ b/Spokast/Features/Search/Coordinator/SearchCoordinator.swift
@@ -1,0 +1,54 @@
+//
+//  SearchCoordinator.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 29/12/25.
+//
+
+import UIKit
+
+final class SearchCoordinator: Coordinator {
+    
+    // MARK: - Properties
+    var navigationController: UINavigationController
+    var childCoordinators: [Coordinator] = []
+    
+    // MARK: - Init
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+    
+    // MARK: - Start
+    func start() {
+        let service = APIService()
+        let viewModel = SearchViewModel(service: service)
+        
+        let viewController = SearchViewController(viewModel: viewModel)
+        viewController.coordinator = self
+        viewController.tabBarItem = UITabBarItem(
+            title: "Search",
+            image: UIImage(systemName: "magnifyingglass"),
+            selectedImage: UIImage(systemName: "magnifyingglass")
+        )
+        
+        navigationController.pushViewController(viewController, animated: false)
+    }
+}
+
+// MARK: - Navigation Delegate
+extension SearchCoordinator: PodcastSelectionDelegate {
+    
+    func didSelectPodcast(_ podcast: Podcast) {
+        let service = APIService()
+        let favoritesRepository = FavoritesRepository()
+        
+        let detailViewModel = PodcastDetailViewModel(
+            podcast: podcast,
+            service: service,
+            favoritesRepository: favoritesRepository
+        )
+        
+        let detailVC = PodcastDetailViewController(viewModel: detailViewModel)
+        navigationController.pushViewController(detailVC, animated: true)
+    }
+}

--- a/Spokast/Features/Search/ViewModels/SearchViewModel.swift
+++ b/Spokast/Features/Search/ViewModels/SearchViewModel.swift
@@ -1,0 +1,68 @@
+//
+//  SearchViewModel.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 29/12/25.
+//
+
+import Foundation
+import Combine
+
+// MARK: - View State
+enum SearchViewState {
+    case idle
+    case loading
+    case success
+    case empty
+    case error(String)
+}
+
+@MainActor
+final class SearchViewModel {
+    
+    // MARK: - Dependencies
+    private let service: APIServiceProtocol
+    
+    // MARK: - Outputs
+    @Published private(set) var podcasts: [Podcast] = []
+    @Published private(set) var state: SearchViewState = .idle
+    
+    // MARK: - Init
+    init(service: APIServiceProtocol) {
+        self.service = service
+    }
+    
+    // MARK: - Public Methods
+    func executeSearch(for term: String) {
+        let query = term.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else {
+            resetSearch()
+            return
+        }
+        
+        state = .loading
+        
+        Task {
+            do {
+                let results = try await service.fetchPodcasts(searchTerm: query, limit: 50)
+                
+                if results.isEmpty {
+                    self.podcasts = []
+                    self.state = .empty
+                } else {
+                    self.podcasts = results
+                    self.state = .success
+                }
+                
+            } catch {
+                let errorMessage = (error as? APIError)?.localizedDescription ?? "Failed to search podcasts."
+                self.state = .error(errorMessage)
+            }
+        }
+    }
+    
+    func resetSearch() {
+        podcasts = []
+        state = .idle
+    }
+}

--- a/Spokast/Features/Search/Views/SearchViewController.swift
+++ b/Spokast/Features/Search/Views/SearchViewController.swift
@@ -1,0 +1,217 @@
+//
+//  SearchViewController.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 29/12/25.
+//
+
+import Foundation
+import UIKit
+import Combine
+
+final class SearchViewController: UIViewController {
+    
+    // MARK: - Properties
+    private let viewModel: SearchViewModel
+    private var cancellables = Set<AnyCancellable>()
+    weak var coordinator: PodcastSelectionDelegate?
+    
+    // MARK: - UI Components
+    private lazy var searchController: UISearchController = {
+        let sc = UISearchController(searchResultsController: nil)
+        sc.obscuresBackgroundDuringPresentation = false
+        sc.searchBar.placeholder = "Find podcasts, artists..."
+        sc.searchBar.tintColor = .systemPurple
+        return sc
+    }()
+    
+    private lazy var tableView: UITableView = {
+        let tv = UITableView()
+        tv.backgroundColor = .systemBackground
+        tv.separatorStyle = .none
+        tv.register(PodcastCell.self, forCellReuseIdentifier: PodcastCell.reuseIdentifier)
+        tv.translatesAutoresizingMaskIntoConstraints = false
+        return tv
+    }()
+    
+    private let activityIndicator: UIActivityIndicatorView = {
+        let spinner = UIActivityIndicatorView(style: .large)
+        spinner.hidesWhenStopped = true
+        spinner.translatesAutoresizingMaskIntoConstraints = false
+        return spinner
+    }()
+    
+    private let emptyLabel: UILabel = {
+        let label = UILabel()
+        label.text = "No results found."
+        label.textColor = .secondaryLabel
+        label.textAlignment = .center
+        label.font = .systemFont(ofSize: 16, weight: .medium)
+        label.isHidden = true
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    // MARK: - Init
+    init(viewModel: SearchViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Lifecycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        definesPresentationContext = true
+        setupUI()
+        setupBindings()
+    }
+    
+    // MARK: - Setup UI
+    private func setupUI() {
+        title = "Search"
+        view.backgroundColor = .systemBackground
+        navigationController?.navigationBar.prefersLargeTitles = true
+        
+        navigationItem.searchController = searchController
+        navigationItem.hidesSearchBarWhenScrolling = false
+        
+        view.addSubview(tableView)
+        view.addSubview(activityIndicator)
+        view.addSubview(emptyLabel)
+        
+        tableView.dataSource = self
+        tableView.delegate = self
+        
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: view.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            
+            activityIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            
+            emptyLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            emptyLabel.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: -50)
+        ])
+    }
+    
+    // MARK: - Bindings
+    private func setupBindings() {
+        bindSearchInput()
+        bindViewModelOutputs()
+    }
+    
+    private func bindSearchInput() {
+        NotificationCenter.default.publisher(
+            for: UISearchTextField.textDidChangeNotification,
+            object: searchController.searchBar.searchTextField
+        )
+        .map { ($0.object as! UISearchTextField).text ?? "" }
+        .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
+        .removeDuplicates()
+        .sink { [weak self] text in
+            self?.handleSearchInput(text)
+        }
+        .store(in: &cancellables)
+    }
+    
+    private func bindViewModelOutputs() {
+        viewModel.$podcasts
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.tableView.reloadData()
+            }
+            .store(in: &cancellables)
+        
+        viewModel.$state
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] state in
+                self?.updateViewForState(state)
+            }
+            .store(in: &cancellables)
+    }
+        
+    private func handleSearchInput(_ text: String) {
+        if text.isEmpty {
+            viewModel.resetSearch()
+        } else {
+            viewModel.executeSearch(for: text)
+        }
+    }
+    
+    // MARK: - View State Management
+    private func updateViewForState(_ state: SearchViewState) {
+        switch state {
+        case .idle:
+            setLayoutState(showTable: false, showLoader: false, showError: false)
+            
+        case .loading:
+            setLayoutState(showTable: false, showLoader: true, showError: false)
+            
+        case .success:
+            setLayoutState(showTable: true, showLoader: false, showError: false)
+            
+        case .empty:
+            setLayoutState(showTable: false, showLoader: false, showError: true)
+            emptyLabel.text = "No results found for \"\(searchController.searchBar.text ?? "")\""
+            
+        case .error(let message):
+            setLayoutState(showTable: false, showLoader: false, showError: true)
+            emptyLabel.text = message
+        }
+    }
+    
+    private func setLayoutState(showTable: Bool, showLoader: Bool, showError: Bool) {
+        tableView.isHidden = !showTable
+        emptyLabel.isHidden = !showError
+        
+        if showLoader {
+            activityIndicator.startAnimating()
+        } else {
+            activityIndicator.stopAnimating()
+        }
+    }
+}
+
+// MARK: - TableView DataSource
+extension SearchViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return viewModel.podcasts.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: PodcastCell.reuseIdentifier, for: indexPath) as? PodcastCell else {
+            return UITableViewCell()
+        }
+        
+        let podcast = viewModel.podcasts[indexPath.row]
+        
+        cell.configure(
+            title: podcast.collectionName,
+            publisher: podcast.artistName,
+            imageUrlString: podcast.artworkUrl100
+        )
+        
+        return cell
+    }
+}
+
+// MARK: - TableView Delegate
+extension SearchViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        
+        let podcast = viewModel.podcasts[indexPath.row]
+        coordinator?.didSelectPodcast(podcast)
+    }
+    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 100
+    }
+}


### PR DESCRIPTION
Summary
This PR introduces the Search Feature as a dedicated tab in the main application. It allows users to actively search for podcasts using the iTunes API. The implementation leverages Combine for reactive input handling and reuses existing UI components to maintain consistency.

Key Changes
Search Module:

Created SearchCoordinator to manage navigation flow within the Search tab.

Implemented SearchViewModel with a strict State Machine (idle, loading, success, empty, error).

Built SearchViewController integrating a native UISearchController.

Reactive Logic:

Implemented a 500ms debounce mechanism using Combine on the search input to minimize API requests.

Bound View States and Data directly to the UI using cancellables.

UI & Navigation:

Reused the existing PodcastCell for search results (DRY principle).

Configured the Tab Bar item with the correct system icon (magnifyingglass) and title.

Fixed navigation context issues by setting definesPresentationContext = true, ensuring the "Back" button functions correctly when navigating to details.

Technical Details
Input Handling: The search input observes UISearchTextField.textDidChangeNotification, applies a debounce, removes duplicates, and triggers the API call only when necessary.

State Management: The UI reacts to SearchViewState. For example, the table view is hidden and an empty state label is shown when the API returns no results (.empty).

Coordinator Integration: The SearchCoordinator conforms to PodcastSelectionDelegate, allowing seamless navigation to the PodcastDetailViewController.

Checklist
[x] Search tab appears correctly in the TabBar.

[x] Typing in the search bar triggers the API call after a short delay (debounce).

[x] Loading spinner appears during data fetching.

[x] "No results found" message is displayed when applicable.

[x] Navigation to Podcast Detail works correctly.

[x] Search bar does not block navigation when pushing a new view controller.