### PR TITLE
feat(player): implement global mini player and playback synchronization

### DIFF
--- a/Spokast/Application/AppCoordinator.swift
+++ b/Spokast/Application/AppCoordinator.swift
@@ -10,45 +10,73 @@ import UIKit
 
 final class AppCoordinator: Coordinator {
     
-    var window: UIWindow
+    // MARK: - Properties
+    var navigationController: UINavigationController
+    var childCoordinators: [Coordinator] = []
+    let window: UIWindow
     
-    private let tabBarController = UITabBarController()
-    private var childCoordinators = [Coordinator]()
-    
+    // MARK: - Init
     init(window: UIWindow) {
         self.window = window
+        self.navigationController = UINavigationController()
     }
     
+    // MARK: - Start
     func start() {
-        let homeNavController = UINavigationController()
-        homeNavController.tabBarItem = UITabBarItem(
+        let homeNav = makeHomeFlow()
+        let searchNav = makeSearchFlow()
+        let favNav = makeFavoritesFlow()
+        
+        let viewControllers = [homeNav, searchNav, favNav]
+        let mainTabBar = MainTabBarController(viewControllers: viewControllers)
+        
+        window.rootViewController = mainTabBar
+        window.makeKeyAndVisible()
+    }
+    
+    // MARK: - Private Factory Methods
+    private func makeHomeFlow() -> UINavigationController {
+        let navController = UINavigationController()
+        navController.tabBarItem = UITabBarItem(
             title: "Discover",
             image: UIImage(systemName: "waveform"),
             selectedImage: UIImage(systemName: "waveform.circle.fill")
         )
-        let homeCoordinator = HomeCoordinator(navigationController: homeNavController)
-        childCoordinators.append(homeCoordinator)
-        homeCoordinator.start()
         
-        let favNavController = UINavigationController()
-        favNavController.tabBarItem = UITabBarItem(
+        let coordinator = HomeCoordinator(navigationController: navController)
+        childCoordinators.append(coordinator)
+        coordinator.start()
+        
+        return navController
+    }
+    
+    private func makeSearchFlow() -> UINavigationController {
+        let navController = UINavigationController()
+        navController.tabBarItem = UITabBarItem(
+            title: "Search",
+            image: UIImage(systemName: "magnifyingglass"),
+            selectedImage: UIImage(systemName: "magnifyingglass.circle.fill")
+        )
+        
+        let coordinator = SearchCoordinator(navigationController: navController)
+        childCoordinators.append(coordinator)
+        coordinator.start()
+        
+        return navController
+    }
+    
+    private func makeFavoritesFlow() -> UINavigationController {
+        let navController = UINavigationController()
+        navController.tabBarItem = UITabBarItem(
             title: "Favorites",
             image: UIImage(systemName: "star"),
             selectedImage: UIImage(systemName: "star.fill")
         )
-        let favCoordinator = FavoritesCoordinator(navigationController: favNavController)
-        childCoordinators.append(favCoordinator)
-        favCoordinator.start()
         
-        let searchNav = UINavigationController()
-        let searchCoordinator = SearchCoordinator(navigationController: searchNav)
-        childCoordinators.append(searchCoordinator)
-        searchCoordinator.start()
+        let coordinator = FavoritesCoordinator(navigationController: navController)
+        childCoordinators.append(coordinator)
+        coordinator.start()
         
-        tabBarController.viewControllers = [homeNavController, favNavController, searchNav]
-        tabBarController.tabBar.tintColor = .systemPurple
-        tabBarController.tabBar.backgroundColor = .systemBackground
-        window.rootViewController = tabBarController
-        window.makeKeyAndVisible()
+        return navController
     }
 }

--- a/Spokast/Core/Audio/AudioPlayerService.swift
+++ b/Spokast/Core/Audio/AudioPlayerService.swift
@@ -1,0 +1,99 @@
+//
+//  AudioPlayerService.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 29/12/25.
+//
+
+import Foundation
+import AVFoundation
+import Combine
+
+protocol AudioPlayerServiceProtocol {
+    var isPlaying: Bool { get }
+    var currentEpisode: Episode? { get }
+    var currentPodcast: Podcast? { get }
+    
+    var playerStatePublisher: Published<Bool>.Publisher { get }
+    var currentEpisodePublisher: Published<Episode?>.Publisher { get }
+    var currentPodcastPublisher: Published<Podcast?>.Publisher { get }
+    
+    func play(episode: Episode, from podcast: Podcast)
+    func togglePlayPause()
+}
+
+final class AudioPlayerService: AudioPlayerServiceProtocol {
+    
+    // MARK: - Singleton
+    static let shared = AudioPlayerService()
+    
+    // MARK: - Properties
+    private var player: AVPlayer?
+    
+    @Published private(set) var isPlaying: Bool = false
+    @Published private(set) var currentEpisode: Episode?
+    @Published private(set) var currentPodcast: Podcast?
+    
+    var playerStatePublisher: Published<Bool>.Publisher { $isPlaying }
+    var currentEpisodePublisher: Published<Episode?>.Publisher { $currentEpisode }
+    var currentPodcastPublisher: Published<Podcast?>.Publisher { $currentPodcast }
+    
+    // MARK: - Init
+    private init() {
+        setupAudioSession()
+    }
+    
+    // MARK: - Public Methods
+    func play(episode: Episode, from podcast: Podcast) {
+        if currentEpisode?.id == episode.id {
+            togglePlayPause()
+            return
+        }
+        
+        guard let url = episode.streamUrl else {
+            print("AudioPlayer: No valid stream URL for episode \(episode.trackName)")
+            return
+        }
+        
+        let playerItem = AVPlayerItem(url: url)
+        player = AVPlayer(playerItem: playerItem)
+        player?.play()
+        
+        self.currentEpisode = episode
+        self.currentPodcast = podcast
+        self.isPlaying = true
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(playerDidFinishPlaying),
+            name: .AVPlayerItemDidPlayToEndTime,
+            object: playerItem
+        )
+    }
+    
+    func togglePlayPause() {
+        guard let player = player else { return }
+        
+        if isPlaying {
+            player.pause()
+            isPlaying = false
+        } else {
+            player.play()
+            isPlaying = true
+        }
+    }
+    
+    @objc private func playerDidFinishPlaying() {
+        isPlaying = false
+    }
+    
+    // MARK: - Private Setup
+    private func setupAudioSession() {
+        do {
+            try AVAudioSession.sharedInstance().setCategory(.playback, mode: .spokenAudio)
+            try AVAudioSession.sharedInstance().setActive(true)
+        } catch {
+            print("Failed to set audio session: \(error)")
+        }
+    }
+}

--- a/Spokast/Core/Navigation/MainTabBarController.swift
+++ b/Spokast/Core/Navigation/MainTabBarController.swift
@@ -1,0 +1,98 @@
+//
+//  MainTabBarController.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 29/12/25.
+//
+
+import UIKit
+import Combine
+
+final class MainTabBarController: UITabBarController {
+    
+    // MARK: - Properties
+    private let miniPlayerViewModel: MiniPlayerViewModel
+    private var cancellables = Set<AnyCancellable>()
+    
+    private lazy var miniPlayerView: MiniPlayerView = {
+        let view = MiniPlayerView(viewModel: miniPlayerViewModel)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.alpha = 0
+        view.isHidden = true
+        return view
+    }()
+    
+    private var playerBottomConstraint: NSLayoutConstraint?
+    
+    // MARK: - Init
+    init(viewControllers: [UIViewController]) {
+        self.miniPlayerViewModel = MiniPlayerViewModel()
+        super.init(nibName: nil, bundle: nil)
+        self.viewControllers = viewControllers
+        setupAppearance()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Lifecycle
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupMiniPlayerLayout()
+        setupBindings()
+    }
+    
+    // MARK: - Setup UI
+    private func setupAppearance() {
+        let appearance = UITabBarAppearance()
+        appearance.configureWithDefaultBackground()
+        appearance.backgroundEffect = UIBlurEffect(style: .systemChromeMaterial)
+        
+        tabBar.standardAppearance = appearance
+        tabBar.scrollEdgeAppearance = appearance
+        tabBar.tintColor = .systemPurple
+    }
+    
+    private func setupMiniPlayerLayout() {
+        view.addSubview(miniPlayerView)
+        view.bringSubviewToFront(tabBar)
+        
+        let playerHeight: CGFloat = 64
+        
+        NSLayoutConstraint.activate([
+            miniPlayerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            miniPlayerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            miniPlayerView.heightAnchor.constraint(equalToConstant: playerHeight),
+            miniPlayerView.bottomAnchor.constraint(equalTo: tabBar.topAnchor)
+        ])
+    }
+    
+    // MARK: - Bindings
+    private func setupBindings() {
+        miniPlayerViewModel.$isVisible
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] shouldShow in
+                self?.animatePlayer(show: shouldShow)
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func animatePlayer(show: Bool) {
+        guard miniPlayerView.isHidden == show else { return }
+        
+        if show {
+            miniPlayerView.isHidden = false
+            UIView.animate(withDuration: 0.3) {
+                self.miniPlayerView.alpha = 1
+            }
+        } else {
+            UIView.animate(withDuration: 0.3, animations: {
+                self.miniPlayerView.alpha = 0
+            }) { _ in
+                self.miniPlayerView.isHidden = true
+            }
+        }
+    }
+}

--- a/Spokast/Features/Favorites/ViewModels/FavoritesViewModel.swift
+++ b/Spokast/Features/Favorites/ViewModels/FavoritesViewModel.swift
@@ -57,6 +57,7 @@ final class FavoritesViewModel {
             releaseDate: Date(),
             trackTimeMillis: 0,
             previewUrl: nil,
+            episodeUrl: nil,
             artworkUrl160: nil,
             collectionName: podcastToRemove.title,
             collectionId: Int(podcastToRemove.id),

--- a/Spokast/Features/Player/ViewModels/MiniPlayerViewModel.swift
+++ b/Spokast/Features/Player/ViewModels/MiniPlayerViewModel.swift
@@ -1,0 +1,63 @@
+//
+//  MiniPlayerViewModel.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 29/12/25.
+//
+
+import Foundation
+import Combine
+
+@MainActor
+final class MiniPlayerViewModel {
+    
+    // MARK: - Dependencies
+    private let service: AudioPlayerService
+    
+    // MARK: - Outputs
+    @Published private(set) var episodeTitle: String = ""
+    @Published private(set) var podcastTitle: String = ""
+    @Published private(set) var imageURL: URL?
+    @Published private(set) var isPlaying: Bool = false
+    @Published private(set) var isVisible: Bool = false
+    
+    private var cancellables = Set<AnyCancellable>()
+    
+    // MARK: - Init
+    init(service: AudioPlayerService = .shared) {
+        self.service = service
+        setupBindings()
+    }
+    
+    // MARK: - User Intent
+    func togglePlayPause() {
+        service.togglePlayPause()
+    }
+    
+    // MARK: - Private Methods
+    private func setupBindings() {
+        service.playerStatePublisher
+            .receive(on: DispatchQueue.main)
+            .assign(to: \.isPlaying, on: self)
+            .store(in: &cancellables)
+        
+        Publishers.CombineLatest(service.currentEpisodePublisher, service.currentPodcastPublisher)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] episode, podcast in
+                guard let self = self else { return }
+                
+                if let episode = episode, let podcast = podcast {
+                    self.isVisible = true
+                    self.episodeTitle = episode.trackName
+                    self.podcastTitle = podcast.collectionName
+                    
+                    let urlString = episode.artworkUrl600 ?? podcast.artworkUrl600 ?? podcast.artworkUrl100
+                    self.imageURL = URL(string: urlString)
+                    
+                } else {
+                    self.isVisible = false
+                }
+            }
+            .store(in: &cancellables)
+    }
+}

--- a/Spokast/Features/Player/Views/MiniPlayerView.swift
+++ b/Spokast/Features/Player/Views/MiniPlayerView.swift
@@ -1,0 +1,185 @@
+//
+//  MiniPlayerView.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 29/12/25.
+//
+
+import Foundation
+import UIKit
+import Combine
+import Kingfisher
+
+final class MiniPlayerView: UIView {
+    
+    // MARK: - Properties
+    private let viewModel: MiniPlayerViewModel
+    private var cancellables = Set<AnyCancellable>()
+    
+    // MARK: - UI Components
+    private let blurView: UIVisualEffectView = {
+        let effect = UIBlurEffect(style: .systemChromeMaterial)
+        let view = UIVisualEffectView(effect: effect)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    private let imageView: UIImageView = {
+        let iv = UIImageView()
+        iv.contentMode = .scaleAspectFill
+        iv.layer.cornerRadius = 8
+        iv.clipsToBounds = true
+        iv.backgroundColor = .secondarySystemBackground
+        iv.translatesAutoresizingMaskIntoConstraints = false
+        return iv
+    }()
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 14, weight: .semibold)
+        label.textColor = .label
+        label.numberOfLines = 1
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private let subtitleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 12, weight: .regular)
+        label.textColor = .secondaryLabel
+        label.numberOfLines = 1
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private lazy var playPauseButton: UIButton = {
+        let btn = UIButton(type: .system)
+        let config = UIImage.SymbolConfiguration(pointSize: 24, weight: .medium)
+        btn.setImage(UIImage(systemName: "play.fill", withConfiguration: config), for: .normal)
+        btn.tintColor = .label
+        btn.addTarget(self, action: #selector(didTapPlayPause), for: .touchUpInside)
+        btn.translatesAutoresizingMaskIntoConstraints = false
+        return btn
+    }()
+    
+    private let progressView: UIProgressView = {
+        let pv = UIProgressView(progressViewStyle: .bar)
+        pv.trackTintColor = .clear
+        pv.progressTintColor = .systemPurple
+        pv.translatesAutoresizingMaskIntoConstraints = false
+        return pv
+    }()
+    
+    private let separatorView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .separator.withAlphaComponent(0.5)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    // MARK: - Init
+    init(viewModel: MiniPlayerViewModel) {
+        self.viewModel = viewModel
+        super.init(frame: .zero)
+        setupLayout()
+        setupBindings()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Actions
+    
+    @objc private func didTapPlayPause() {
+        viewModel.togglePlayPause()
+    }
+    
+    // MARK: - Bindings
+    private func setupBindings() {
+        bindLabels()
+        bindImages()
+        bindControls()
+    }
+    
+    private func bindLabels() {
+        viewModel.$episodeTitle
+            .map { $0 as String? }
+            .assign(to: \.text, on: titleLabel)
+            .store(in: &cancellables)
+        
+        viewModel.$podcastTitle
+            .map { $0 as String? }
+            .assign(to: \.text, on: subtitleLabel)
+            .store(in: &cancellables)
+    }
+    
+    private func bindImages() {
+        viewModel.$imageURL
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] url in
+                self?.imageView.kf.setImage(with: url, placeholder: UIImage(systemName: "music.note"))
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func bindControls() {
+        viewModel.$isPlaying
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isPlaying in
+                let iconName = isPlaying ? "pause.fill" : "play.fill"
+                let config = UIImage.SymbolConfiguration(pointSize: 24, weight: .medium)
+                self?.playPauseButton.setImage(UIImage(systemName: iconName, withConfiguration: config), for: .normal)
+            }
+            .store(in: &cancellables)
+    }
+    
+    // MARK: - Layout
+    private func setupLayout() {
+        addSubview(blurView)
+        NSLayoutConstraint.activate([
+            blurView.topAnchor.constraint(equalTo: topAnchor),
+            blurView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            blurView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            blurView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+        
+        addSubview(progressView)
+        addSubview(separatorView)
+        addSubview(imageView)
+        addSubview(titleLabel)
+        addSubview(subtitleLabel)
+        addSubview(playPauseButton)
+        
+        NSLayoutConstraint.activate([
+            separatorView.topAnchor.constraint(equalTo: topAnchor),
+            separatorView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            separatorView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            separatorView.heightAnchor.constraint(equalToConstant: 0.5),
+            
+            imageView.topAnchor.constraint(equalTo: topAnchor, constant: 8),
+            imageView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8),
+            imageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 16),
+            imageView.widthAnchor.constraint(equalTo: imageView.heightAnchor), // Quadrada
+            
+            playPauseButton.centerYAnchor.constraint(equalTo: centerYAnchor),
+            playPauseButton.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            playPauseButton.widthAnchor.constraint(equalToConstant: 44),
+            playPauseButton.heightAnchor.constraint(equalToConstant: 44),
+            
+            titleLabel.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: 12),
+            titleLabel.trailingAnchor.constraint(equalTo: playPauseButton.leadingAnchor, constant: -12),
+            titleLabel.topAnchor.constraint(equalTo: imageView.topAnchor, constant: 4),
+            
+            subtitleLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+            subtitleLabel.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
+            subtitleLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 2),
+            
+            progressView.topAnchor.constraint(equalTo: topAnchor),
+            progressView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            progressView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            progressView.heightAnchor.constraint(equalToConstant: 2)
+        ])
+    }
+}

--- a/Spokast/Features/PodcastDetail/ViewModels/PodcastDetailViewModel.swift
+++ b/Spokast/Features/PodcastDetail/ViewModels/PodcastDetailViewModel.swift
@@ -134,6 +134,7 @@ final class PodcastDetailViewModel {
             releaseDate: Date(),
             trackTimeMillis: 0,
             previewUrl: nil,
+            episodeUrl: nil,
             artworkUrl160: podcast.artworkUrl100,
             collectionName: podcast.collectionName,
             collectionId: podcast.trackId ?? 0,

--- a/Spokast/Features/PodcastDetail/ViewModels/PodcastDetailViewModel.swift
+++ b/Spokast/Features/PodcastDetail/ViewModels/PodcastDetailViewModel.swift
@@ -13,7 +13,7 @@ final class PodcastDetailViewModel {
     // MARK: - Properties
     private let podcast: Podcast
     private let service: APIService
-    private let audioService: AudioPlayerProtocol
+    private let audioPlayerService: AudioPlayerServiceProtocol
     private let favoritesRepository: FavoritesRepositoryProtocol
     private var cancellables = Set<AnyCancellable>()
     
@@ -23,13 +23,18 @@ final class PodcastDetailViewModel {
     @Published private(set) var currentPlayingEpisodeId: Int? = nil
     @Published private(set) var isPlayerPaused: Bool = false
     @Published private(set) var isFavorite: Bool = false
+    @Published var isPlaying: Bool = false
+    @Published var currentPlayingID: Int?
     
     // MARK: - Initialization
-    init(podcast: Podcast, service: APIService, audioService: AudioPlayerProtocol = AudioService.shared, favoritesRepository: FavoritesRepositoryProtocol) {
+    init(podcast: Podcast,
+         service: APIService,
+         favoritesRepository: FavoritesRepositoryProtocol,
+         audioPlayerService: AudioPlayerServiceProtocol = AudioPlayerService.shared) {
         self.podcast = podcast
         self.service = service
-        self.audioService = audioService
         self.favoritesRepository = favoritesRepository
+        self.audioPlayerService = audioPlayerService
         
         setupAudioObserver()
         checkFavoriteStatus()
@@ -87,43 +92,25 @@ final class PodcastDetailViewModel {
     func playEpisode(at index: Int) {
         guard episodes.indices.contains(index) else { return }
         let episode = episodes[index]
-        
-        guard let urlString = episode.previewUrl, let url = URL(string: urlString) else {
-            self.errorMessage = "Audio preview not available."
-            return
-        }
-        audioService.toggle(url: url)
+        audioPlayerService.play(episode: episode, from: podcast)
+    }
+    
+    func didTapPlay(episode: Episode) {
+        audioPlayerService.play(episode: episode, from: podcast)
     }
     
     // MARK: - Private Setup & Helpers
     private func setupAudioObserver() {
-        audioService.playerState
+        audioPlayerService.playerStatePublisher
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] state in
-                guard let self = self else { return }
-                self.handleAudioStateChange(state)
-            }
+            .assign(to: \.isPlaying, on: self)
             .store(in: &cancellables)
-    }
-    
-    private func handleAudioStateChange(_ state: AudioPlayerState) {
-        switch state {
-        case .stopped:
-            self.currentPlayingEpisodeId = nil
-            self.isPlayerPaused = false
-            
-        case .playing(let url):
-            self.isPlayerPaused = false
-            if let episode = self.episodes.first(where: { $0.previewUrl == url.absoluteString }) {
-                self.currentPlayingEpisodeId = episode.trackId
-            }
-            
-        case .paused(let url):
-            self.isPlayerPaused = true
-            if let episode = self.episodes.first(where: { $0.previewUrl == url.absoluteString }) {
-                self.currentPlayingEpisodeId = episode.trackId
-            }
-        }
+        
+        audioPlayerService.currentEpisodePublisher
+            .receive(on: DispatchQueue.main)
+            .map { $0?.id }
+            .assign(to: \.currentPlayingID, on: self)
+            .store(in: &cancellables)
     }
     
     private func makeRepresentativeEpisode() -> Episode {

--- a/Spokast/Features/PodcastDetail/Views/Cells/EpisodeCell.swift
+++ b/Spokast/Features/PodcastDetail/Views/Cells/EpisodeCell.swift
@@ -12,12 +12,16 @@ final class EpisodeCell: UITableViewCell {
 
     static let reuseIdentifier = "EpisodeCell"
     
+    // MARK: - Actions
+    var onPlayTap: (() -> Void)?
+    
     // MARK: - UI Components
-    private let playIconContainer: UIView = {
+    private lazy var playIconContainer: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.backgroundColor = .systemPurple.withAlphaComponent(0.1)
         view.layer.cornerRadius = 20
+        view.isUserInteractionEnabled = true
         return view
     }()
     
@@ -56,11 +60,12 @@ final class EpisodeCell: UITableViewCell {
         stack.alignment = .leading
         return stack
     }()
-
+    
     // MARK: - Initialization
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupUI()
+        setupGestures()
     }
     
     @available(*, unavailable)
@@ -69,7 +74,7 @@ final class EpisodeCell: UITableViewCell {
     }
     
     // MARK: - Configuration
-    func configure(with episode: Episode) {
+    func configure(with episode: Episode, isPlaying: Bool) {
         titleLabel.text = episode.trackName
         
         let dateFormatter = DateFormatter()
@@ -78,8 +83,7 @@ final class EpisodeCell: UITableViewCell {
         let durationText = formatDuration(millis: episode.trackTimeMillis)
         
         descriptionLabel.text = "\(dateString) • \(durationText)"
-        playImageView.image = UIImage(systemName: "play.fill")
-        playIconContainer.backgroundColor = .systemPurple.withAlphaComponent(0.1)
+        updatePlaybackState(isPlaying: isPlaying)
     }
     
     // MARK: - Helpers
@@ -106,11 +110,29 @@ final class EpisodeCell: UITableViewCell {
         
         playIconContainer.backgroundColor = isPlaying ? .systemPurple.withAlphaComponent(0.3) : .systemPurple.withAlphaComponent(0.1)
     }
-
+    
+    // MARK: - Gestures
+    private func setupGestures() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(didTapPlayContainer))
+        playIconContainer.addGestureRecognizer(tapGesture)
+    }
+    
+    @objc private func didTapPlayContainer() {
+        UIView.animate(withDuration: 0.1, animations: {
+            self.playIconContainer.transform = CGAffineTransform(scaleX: 0.9, y: 0.9)
+        }) { _ in
+            UIView.animate(withDuration: 0.1) {
+                self.playIconContainer.transform = .identity
+            }
+        }
+        onPlayTap?()
+    }
+    
     // MARK: - UI Setup
     private func setupUI() {
         backgroundColor = .systemBackground
         selectionStyle = .default
+        
         contentView.addSubview(playIconContainer)
         playIconContainer.addSubview(playImageView)
         contentView.addSubview(textStackView)

--- a/Spokast/Models/Episode.swift
+++ b/Spokast/Models/Episode.swift
@@ -15,6 +15,7 @@ struct Episode: Decodable, Identifiable {
     let releaseDate: Date
     let trackTimeMillis: Int?
     let previewUrl: String?
+    let episodeUrl: String?
     let artworkUrl160: String?
     let collectionName: String?
     let collectionId: Int
@@ -25,6 +26,13 @@ struct Episode: Decodable, Identifiable {
         return Double(millis) / 1000.0
     }
     
+    var streamUrl: URL? {
+        if let urlString = episodeUrl ?? previewUrl {
+            return URL(string: urlString)
+        }
+        return nil
+    }
+    
     enum CodingKeys: String, CodingKey {
         case trackId
         case trackName
@@ -32,6 +40,7 @@ struct Episode: Decodable, Identifiable {
         case releaseDate
         case trackTimeMillis
         case previewUrl
+        case episodeUrl
         case artworkUrl160
         case collectionName
         case collectionId


### PR DESCRIPTION
Description
This PR introduces the Global Mini Player, a persistent UI component that stays visible across the application, allowing users to control playback while navigating. It also establishes the synchronization logic between the global PlayerService, the Mini Player, and the Episode List screens.

🛠 Key Changes
1. Mini Player Component (MiniPlayerView & ViewModel)

Created the MiniPlayerView UI with Play/Pause controls, episode title, and artwork.

Implemented MiniPlayerViewModel using Combine to observe PlayerService states.

Refactor: Organized the setupBindings method in the view to clearly separate text, visual, and control logic (Clean Code).

2. List Integration (PodcastDetail & EpisodeCell)

Refactored EpisodeCell to dynamic toggle icons (Play/Pause) based on the global state.

Updated PodcastDetailViewModel to expose isPlaying and currentPlayingID for UI binding.

Ensured the list reloads/updates when the global player state changes.

3. Architecture & Cleanup

Integrated the MiniPlayerView into the main view hierarchy (e.g., MainTabBarController).

Removed deprecated references to the old AudioService.

📱 How to test?
Scenario A: Mini Player Interaction

Launch the app and start playing an episode.

Verify: The Mini Player appears at the bottom of the screen.

Navigate to different tabs/screens.

Verify: The Mini Player persists and remains functional.

Pause/Play via the Mini Player.

Scenario B: List Synchronization

Go to the "Podcast Details" screen of the currently playing episode.

Verify: The specific episode cell shows a "Pause" icon.

Pause the audio using the Mini Player.

Verify: The episode cell icon in the list instantly flips to "Play".