### PR TITLE
fix(favorites): map artist name correctly and refactor repo to use Podcast struct

### DIFF
--- a/Spokast/Features/Favorites/ViewModels/FavoritesViewModel.swift
+++ b/Spokast/Features/Favorites/ViewModels/FavoritesViewModel.swift
@@ -50,23 +50,8 @@ final class FavoritesViewModel {
         guard podcasts.indices.contains(index) else { return }
         let podcastToRemove = podcasts[index]
         
-        let dummyEpisode = Episode(
-            trackId: 0,
-            trackName: "",
-            description: nil,
-            releaseDate: Date(),
-            trackTimeMillis: 0,
-            previewUrl: nil,
-            episodeUrl: nil,
-            artworkUrl160: nil,
-            collectionName: podcastToRemove.title,
-            collectionId: Int(podcastToRemove.id),
-            artworkUrl600: podcastToRemove.coverUrl
-        )
-        
         do {
-            _ = try repository.togglePodcastSubscription(for: dummyEpisode)
-
+            try repository.removePodcast(id: podcastToRemove.id)
             loadFavorites()
         } catch {
             print("❌ Error removing favorite: \(error)")

--- a/Spokast/Features/Player/ViewModels/PlayerViewModel.swift
+++ b/Spokast/Features/Player/ViewModels/PlayerViewModel.swift
@@ -71,13 +71,13 @@ final class PlayerViewModel {
     }
     
     func didTapFavorite() {
-            do {
-                let newState = try favoritesRepository.togglePodcastSubscription(for: episode)
-                isFavorite = newState
-            } catch {
-                print("❌ Error toggling subscription: \(error)")
-            }
+        do {
+            let newState = try favoritesRepository.togglePodcastSubscription(for: episode.asPodcast)
+            isFavorite = newState
+        } catch {
+            print("❌ Error toggling subscription: \(error)")
         }
+    }
     
     // MARK: - Private Setup
     private func checkFavoriteStatus() {

--- a/Spokast/Features/PodcastDetail/ViewModels/PodcastDetailViewModel.swift
+++ b/Spokast/Features/PodcastDetail/ViewModels/PodcastDetailViewModel.swift
@@ -78,10 +78,8 @@ final class PodcastDetailViewModel {
     }
     
     func didTapSubscribe() {
-        let podcastAsEpisode = makeRepresentativeEpisode()
-        
         do {
-            let newState = try favoritesRepository.togglePodcastSubscription(for: podcastAsEpisode)
+            let newState = try favoritesRepository.togglePodcastSubscription(for: self.podcast)
             isFavorite = newState
         } catch {
             print("❌ Error toggling subscription: \(error)")
@@ -111,21 +109,5 @@ final class PodcastDetailViewModel {
             .map { $0?.id }
             .assign(to: \.currentPlayingID, on: self)
             .store(in: &cancellables)
-    }
-    
-    private func makeRepresentativeEpisode() -> Episode {
-        return Episode(
-            trackId: 0,
-            trackName: "Podcast Info",
-            description: nil,
-            releaseDate: Date(),
-            trackTimeMillis: 0,
-            previewUrl: nil,
-            episodeUrl: nil,
-            artworkUrl160: podcast.artworkUrl100,
-            collectionName: podcast.collectionName,
-            collectionId: podcast.trackId ?? 0,
-            artworkUrl600: podcast.artworkUrl600
-        )
     }
 }

--- a/Spokast/Models/Episode.swift
+++ b/Spokast/Models/Episode.swift
@@ -20,6 +20,7 @@ struct Episode: Decodable, Identifiable {
     let collectionName: String?
     let collectionId: Int
     let artworkUrl600: String?
+    let artistName: String?
     
     var durationInSeconds: Double {
         guard let millis = trackTimeMillis else { return 0.0 }
@@ -45,5 +46,20 @@ struct Episode: Decodable, Identifiable {
         case collectionName
         case collectionId
         case artworkUrl600
+        case artistName
+    }
+}
+
+extension Episode {
+    var asPodcast: Podcast {
+        return Podcast(
+            trackId: collectionId, 
+            artistName: artistName ?? "Unknown Artist",
+            collectionName: collectionName ?? "Unknown Podcast",
+            artworkUrl100: artworkUrl160 ?? "",
+            feedUrl: nil,
+            artworkUrl600: artworkUrl600,
+            primaryGenreName: nil
+        )
     }
 }


### PR DESCRIPTION
Description:

Summary This PR fixes a data mapping issue in the Favorites module where the artist name was missing when navigating to the details screen. It also refactors the selection logic to correctly convert Core Data objects into the domain Podcast struct.

Key Changes

Refactored didSelectRowAt in FavoritesViewController to correctly instantiate Podcast structs from FavoritePodcast (Core Data) objects.

Explicitly mapped the author property from Core Data to artistName in the domain model to prevent empty strings.

Fixed the navigation flow ensuring the Coordinator receives a valid model.

How to Test

Launch the app and go to the Favorites tab.

Tap on any podcast in the list.

Verify: The app should navigate to the Details screen without errors.

Verify: The Details screen should display the correct Artist Name and Title (instead of "Unknown" or nil).