### PR TITLE
feat(episodes): introduce episode detail screen with MVVM and refactor navigation

### DIFF
--- a/Spokast/Features/Episodes/ViewModels/EpisodeDetailViewModel.swift
+++ b/Spokast/Features/Episodes/ViewModels/EpisodeDetailViewModel.swift
@@ -1,0 +1,59 @@
+//
+//  EpisodeDetailViewModel.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 02/01/26.
+//
+
+import Foundation
+
+final class EpisodeDetailViewModel {
+    
+    // MARK: - Properties
+    private let episode: Episode
+    private let podcast: Podcast
+    
+    // MARK: - Init
+    init(episode: Episode, podcast: Podcast) {
+        self.episode = episode
+        self.podcast = podcast
+    }
+    
+    // MARK: - Outputs
+    var title: String {
+        return episode.trackName
+    }
+    
+    var podcastName: String {
+        return podcast.artistName
+    }
+    
+    var description: String {
+        return episode.description ?? ""
+    }
+    
+    var imageURL: URL? {
+        if let urlString = episode.artworkUrl600, let url = URL(string: urlString) {
+            return url
+        }
+        
+        if let urlString = episode.artworkUrl160, let url = URL(string: urlString) {
+            return url
+        }
+        
+        if let urlString = podcast.artworkUrl600, let url = URL(string: urlString) {
+            return url
+        }
+        
+        return URL(string: podcast.artworkUrl100)
+    }
+    
+    
+    func getEpisode() -> Episode {
+        return episode
+    }
+    
+    func getPodcast() -> Podcast {
+        return podcast
+    }
+}

--- a/Spokast/Features/Episodes/Views/EpisodeDetailView.swift
+++ b/Spokast/Features/Episodes/Views/EpisodeDetailView.swift
@@ -1,0 +1,157 @@
+//
+//  EpisodeDetailView.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 01/01/26.
+//
+
+import Foundation
+import UIKit
+import Kingfisher
+
+final class EpisodeDetailView: UIView {
+    
+    // MARK: - Actions
+    var onPlayTap: (() -> Void)?
+
+    // MARK: - UI Components
+    private lazy var scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        return scrollView
+    }()
+    
+    private lazy var contentView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+    
+    private lazy var artworkImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        imageView.layer.cornerRadius = 12
+        imageView.clipsToBounds = true
+        imageView.backgroundColor = .secondarySystemBackground
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        return imageView
+    }()
+    
+    private lazy var podcastNameLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 16, weight: .medium)
+        label.textColor = .secondaryLabel
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 24, weight: .bold)
+        label.numberOfLines = 0
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+    
+    private lazy var playButton: UIButton = {
+        var config = UIButton.Configuration.filled()
+        config.title = "Play"
+        config.image = UIImage(systemName: "play.fill")
+        config.imagePadding = 10
+        config.cornerStyle = .capsule
+        config.baseBackgroundColor = .systemPurple
+        config.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
+            var outgoing = incoming
+            outgoing.font = .systemFont(ofSize: 16, weight: .semibold)
+            return outgoing
+        }
+        
+        let btn = UIButton(configuration: config)
+        btn.addTarget(self, action: #selector(didTapPlay), for: .touchUpInside)
+        btn.translatesAutoresizingMaskIntoConstraints = false
+        return btn
+    }()
+    
+    private lazy var descriptionTextView: UITextView = {
+        let tv = UITextView()
+        tv.font = .systemFont(ofSize: 16)
+        tv.isEditable = false
+        tv.isScrollEnabled = false
+        tv.backgroundColor = .clear
+        tv.textColor = .label
+        tv.translatesAutoresizingMaskIntoConstraints = false
+        return tv
+    }()
+
+    // MARK: - Init
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .systemBackground
+        setupLayout()
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Public Config
+    func configure(with episode: Episode, podcast: Podcast, podcastImageURL: URL?) {
+        titleLabel.text = episode.trackName
+        podcastNameLabel.text = podcast.artistName
+        descriptionTextView.text = episode.description
+        artworkImageView.kf.setImage(with: podcastImageURL)
+    }
+
+    // MARK: - Layout
+    private func setupLayout() {
+        addSubview(scrollView)
+        scrollView.addSubview(contentView)
+        
+        contentView.addSubview(artworkImageView)
+        contentView.addSubview(podcastNameLabel)
+        contentView.addSubview(titleLabel)
+        contentView.addSubview(playButton)
+        contentView.addSubview(descriptionTextView)
+        
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            
+            contentView.topAnchor.constraint(equalTo: scrollView.topAnchor),
+            contentView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            contentView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            contentView.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
+            
+            artworkImageView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 20),
+            artworkImageView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            artworkImageView.widthAnchor.constraint(equalTo: contentView.widthAnchor, multiplier: 0.6),
+            artworkImageView.heightAnchor.constraint(equalTo: artworkImageView.widthAnchor),
+            
+            podcastNameLabel.topAnchor.constraint(equalTo: artworkImageView.bottomAnchor, constant: 20),
+            podcastNameLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            podcastNameLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+            
+            titleLabel.topAnchor.constraint(equalTo: podcastNameLabel.bottomAnchor, constant: 12),
+            titleLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            titleLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+            
+            playButton.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 24),
+            playButton.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            playButton.widthAnchor.constraint(equalToConstant: 120),
+            playButton.heightAnchor.constraint(equalToConstant: 44),
+            
+            descriptionTextView.topAnchor.constraint(equalTo: playButton.bottomAnchor, constant: 24),
+            descriptionTextView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20),
+            descriptionTextView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20),
+            descriptionTextView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -20)
+        ])
+    }
+    
+    @objc private func didTapPlay() {
+        onPlayTap?()
+    }
+}

--- a/Spokast/Features/Episodes/Views/EpisodeDetailViewController.swift
+++ b/Spokast/Features/Episodes/Views/EpisodeDetailViewController.swift
@@ -1,0 +1,65 @@
+//
+//  EpisodeDetailViewController.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 01/01/26.
+//
+
+import Foundation
+import UIKit
+
+final class EpisodeDetailViewController: UIViewController {
+
+    // MARK: - Properties
+    private let viewModel: EpisodeDetailViewModel
+    
+    private var customView: EpisodeDetailView? {
+        return view as? EpisodeDetailView
+    }
+
+    // MARK: - Init
+    init(viewModel: EpisodeDetailViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+        self.title = "Details"
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+    override func loadView() {
+        self.view = EpisodeDetailView()
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        navigationItem.largeTitleDisplayMode = .never
+        setupConfiguration()
+        setupActions()
+    }
+    
+    // MARK: - Setup
+    private func setupConfiguration() {
+        customView?.configure(
+            with: viewModel.getEpisode(),
+            podcast: viewModel.getPodcast(),
+            podcastImageURL: viewModel.imageURL
+        )
+    }
+    
+    private func setupActions() {
+        customView?.onPlayTap = { [weak self] in
+            self?.playEpisode()
+        }
+    }
+    
+    private func playEpisode() {
+        AudioPlayerService.shared.play(
+            episode: viewModel.getEpisode(),
+            from: viewModel.getPodcast()
+        )
+    }
+}

--- a/Spokast/Features/Favorites/Coordinator/FavoritesCoordinator.swift
+++ b/Spokast/Features/Favorites/Coordinator/FavoritesCoordinator.swift
@@ -26,17 +26,19 @@ final class FavoritesCoordinator: Coordinator {
 
 extension FavoritesCoordinator: PodcastSelectionDelegate {
     func didSelectPodcast(_ podcast: Podcast) {
-            let service = APIService()
-            let favoritesRepository = FavoritesRepository()
-            
-            let detailViewModel = PodcastDetailViewModel(
-                podcast: podcast,
-                service: service,
-                favoritesRepository: favoritesRepository
-            )
-            
-            let detailVC = PodcastDetailViewController(viewModel: detailViewModel)
-            
-            navigationController.pushViewController(detailVC, animated: true)
-        }
+        let service = APIService()
+        let favoritesRepository = FavoritesRepository()
+        
+        let detailViewModel = PodcastDetailViewModel(
+            podcast: podcast,
+            service: service,
+            favoritesRepository: favoritesRepository
+        )
+        
+        let detailVC = PodcastDetailViewController(viewModel: detailViewModel)
+        detailVC.coordinator = self
+        navigationController.pushViewController(detailVC, animated: true)
+    }
 }
+
+extension FavoritesCoordinator: PodcastDetailCoordinatorDelegate {}

--- a/Spokast/Features/Home/HomeCoordinator.swift
+++ b/Spokast/Features/Home/HomeCoordinator.swift
@@ -59,3 +59,5 @@ extension HomeCoordinator: HomeViewControllerDelegate {
         navigationController.pushViewController(detailViewController, animated: true)
     }
 }
+
+extension HomeCoordinator: PodcastDetailCoordinatorDelegate {}

--- a/Spokast/Features/PodcastDetail/ViewModels/PodcastDetailViewModel.swift
+++ b/Spokast/Features/PodcastDetail/ViewModels/PodcastDetailViewModel.swift
@@ -11,7 +11,7 @@ import Combine
 final class PodcastDetailViewModel {
 
     // MARK: - Properties
-    private let podcast: Podcast
+    let podcast: Podcast
     private let service: APIService
     private let audioPlayerService: AudioPlayerServiceProtocol
     private let favoritesRepository: FavoritesRepositoryProtocol

--- a/Spokast/Features/PodcastDetail/Views/PodcastDetailViewController.swift
+++ b/Spokast/Features/PodcastDetail/Views/PodcastDetailViewController.swift
@@ -10,6 +10,11 @@ import UIKit
 import Kingfisher
 import Combine
 
+protocol PodcastDetailCoordinatorDelegate: AnyObject {
+    var navigationController: UINavigationController { get }
+    func showEpisodeDetails(_ episode: Episode, from podcast: Podcast)
+}
+
 final class PodcastDetailViewController: UIViewController {
     
     // MARK: - Properties
@@ -20,7 +25,7 @@ final class PodcastDetailViewController: UIViewController {
     }
     
     private var cancellables = Set<AnyCancellable>()
-    weak var coordinator: HomeCoordinator?
+    weak var coordinator: PodcastDetailCoordinatorDelegate?
     
     // MARK: - Initialization
     init(viewModel: PodcastDetailViewModel) {
@@ -176,14 +181,21 @@ extension PodcastDetailViewController: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        viewModel.playEpisode(at: indexPath.row)
-        
         let episode = viewModel.episodes[indexPath.row]
-        viewModel.didTapPlay(episode: episode)
-        coordinator?.presentPlayer(for: episode, podcastImageURL: viewModel.coverImageURL)
+        coordinator?.showEpisodeDetails(episode, from: viewModel.podcast)
     }
     
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return 300
+    }
+}
+
+extension PodcastDetailCoordinatorDelegate {
+    
+    func showEpisodeDetails(_ episode: Episode, from podcast: Podcast) {
+        let viewModel = EpisodeDetailViewModel(episode: episode, podcast: podcast)
+        let episodeDetailVC = EpisodeDetailViewController(viewModel: viewModel)
+        
+        navigationController.pushViewController(episodeDetailVC, animated: true)
     }
 }

--- a/Spokast/Features/Search/Coordinator/SearchCoordinator.swift
+++ b/Spokast/Features/Search/Coordinator/SearchCoordinator.swift
@@ -49,6 +49,9 @@ extension SearchCoordinator: PodcastSelectionDelegate {
         )
         
         let detailVC = PodcastDetailViewController(viewModel: detailViewModel)
+        detailVC.coordinator = self
         navigationController.pushViewController(detailVC, animated: true)
     }
 }
+
+extension SearchCoordinator: PodcastDetailCoordinatorDelegate {}


### PR DESCRIPTION
Summary This PR introduces a dedicated Episode Detail screen to display extended information about a selected episode (artwork, description, podcast name). It implements the MVVM pattern to handle presentation logic and refactors the coordinator navigation flow using Protocol Extensions to reduce boilerplate code.

Key Changes

New Feature: Added EpisodeDetailViewController, EpisodeDetailViewModel, and EpisodeDetailView (ViewCode).

Architecture: Implemented MVVM to handle image fallback logic (Episode Artwork > Podcast Artwork) and data formatting.

Refactor: Updated PodcastDetailCoordinatorDelegate with a Protocol Extension to provide a default implementation for showEpisodeDetails. This removed code duplication from HomeCoordinator, FavoritesCoordinator, and SearchCoordinator.

UI/UX: Designed a clean layout featuring high-quality artwork (using Kingfisher) and a refined "Play" button.

Dependency: Integrated Kingfisher for asynchronous image loading in the detail view.

How to Test

Launch the app and navigate to any episode list (Home, Favorites, or Search).

Tap on an episode.

Verify: The Episode Detail screen opens with the correct metadata and artwork.

Check fallback: If an episode has no specific artwork, the podcast artwork should be displayed.

Tap the "Play" button.

Verify: Audio starts playing via AudioPlayerService.