### PR TITLE
feat(ui): add artwork to episode list and refine cell layout

### DIFF
--- a/Spokast/Features/PodcastDetail/Views/PodcastDetailViewController.swift
+++ b/Spokast/Features/PodcastDetail/Views/PodcastDetailViewController.swift
@@ -161,17 +161,27 @@ extension PodcastDetailViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: "EpisodeCell", for: indexPath) as? EpisodeCell else {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: EpisodeCell.reuseIdentifier, for: indexPath) as? EpisodeCell else {
             return UITableViewCell()
         }
         
         let episode = viewModel.episodes[indexPath.row]
+        
+        let podcastArtString = viewModel.podcast.artworkUrl600 ?? viewModel.podcast.artworkUrl100
+        let podcastArtURL = URL(string: podcastArtString)
         let isPlayingThisEpisode = viewModel.isPlaying && (viewModel.currentPlayingID == episode.id)
+        
 
-        cell.configure(with: episode, isPlaying: isPlayingThisEpisode)
+        cell.configure(
+            with: episode,
+            podcastArtURL: podcastArtURL,
+            isPlaying: isPlayingThisEpisode
+        )
+        
         cell.onPlayTap = { [weak self] in
             self?.viewModel.playEpisode(at: indexPath.row)
         }
+        
         return cell
     }
 }


### PR DESCRIPTION
Summary This PR enhances the Episode List UI by incorporating artwork into the cell layout. Instead of a generic play button, the cell now displays the episode's artwork (with a fallback to the podcast cover) behind the play icon, creating a more engaging and modern visual experience.

Key Changes

EpisodeCell:

Integrated Kingfisher for asynchronous image loading.

Added a dark overlay to ensure the "Play" icon remains visible against any background image.

Updated layout dimensions: Artwork increased to 60x60pt; Play icon to 24pt.

Refined Typography: Adjusted Title (15pt) and Description (13pt) for better visual hierarchy.

PodcastDetailViewController:

Updated cellForRowAt to extract and pass the podcast artwork URL as a fallback when the episode has no specific image.

Visual Changes

The list now features rounded square artwork for each episode.

Typography is balanced to emphasize the artwork while keeping the text readable.

How to Test

Open the app and select a podcast.

Verify: The list of episodes now displays images.

Episodes with specific artwork show their own cover.

Episodes without artwork show the Podcast's cover.

Verify: The "Play" icon is clearly visible (white) over the darkened image.

Tap the play button/cell to ensure navigation/playback still works as expected.