### PR TITLE
feat(player): implement playback speed control and dynamic time display

### DIFF
--- a/Spokast/Features/Player/Views/PlayerView.swift
+++ b/Spokast/Features/Player/Views/PlayerView.swift
@@ -119,6 +119,17 @@ final class PlayerView: UIView {
         return button
     }()
     
+    let speedButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.titleLabel?.font = .systemFont(ofSize: 15, weight: .bold)
+        button.setTitle("1.0x", for: .normal)
+        button.tintColor = .label
+        button.backgroundColor = .secondarySystemBackground
+        button.layer.cornerRadius = 8
+        return button
+    }()
+    
     private lazy var controlsStackView: UIStackView = {
         let stack = UIStackView(arrangedSubviews: [rewindButton, playPauseButton, forwardButton])
         stack.translatesAutoresizingMaskIntoConstraints = false
@@ -128,6 +139,13 @@ final class PlayerView: UIView {
         stack.spacing = 40
         return stack
     }()
+    
+    private lazy var speedContainerView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(speedButton)
+        return view
+    }()
 
     private lazy var mainStackView: UIStackView = {
         let stack = UIStackView(arrangedSubviews: [
@@ -136,7 +154,8 @@ final class PlayerView: UIView {
             artistLabel,
             progressSlider,
             timeStackView,
-            controlsStackView
+            controlsStackView,
+            speedContainerView
         ])
         stack.translatesAutoresizingMaskIntoConstraints = false
         stack.axis = .vertical
@@ -184,10 +203,19 @@ final class PlayerView: UIView {
             
             coverContainerView.heightAnchor.constraint(equalTo: coverContainerView.widthAnchor),
             
+            speedButton.centerXAnchor.constraint(equalTo: speedContainerView.centerXAnchor),
+            speedButton.topAnchor.constraint(equalTo: speedContainerView.topAnchor),
+            speedButton.bottomAnchor.constraint(equalTo: speedContainerView.bottomAnchor),
+            speedButton.heightAnchor.constraint(equalToConstant: 36),
+            speedButton.widthAnchor.constraint(equalToConstant: 100),
+            
             coverImageView.topAnchor.constraint(equalTo: coverContainerView.topAnchor),
             coverImageView.leadingAnchor.constraint(equalTo: coverContainerView.leadingAnchor),
             coverImageView.trailingAnchor.constraint(equalTo: coverContainerView.trailingAnchor),
             coverImageView.bottomAnchor.constraint(equalTo: coverContainerView.bottomAnchor),
+            
+            playPauseButton.heightAnchor.constraint(equalToConstant: 64),
+            playPauseButton.widthAnchor.constraint(equalToConstant: 64),
             
             mainStackView.topAnchor.constraint(equalTo: grabberView.bottomAnchor, constant: 32),
             mainStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24),

--- a/Spokast/Features/Player/Views/PlayerViewController.swift
+++ b/Spokast/Features/Player/Views/PlayerViewController.swift
@@ -48,6 +48,7 @@ final class PlayerViewController: UIViewController {
         customView.forwardButton.addTarget(self, action: #selector(didTapForward), for: .touchUpInside)
         customView.rewindButton.addTarget(self, action: #selector(didTapRewind), for: .touchUpInside)
         customView.progressSlider.addTarget(self, action: #selector(didScrubSlider(_:)), for: .valueChanged)
+        customView.speedButton.addTarget(self, action: #selector(didTapSpeedButton), for: .touchUpInside)
     }
     
     @objc private func didScrubSlider(_ sender: UISlider) {
@@ -67,6 +68,10 @@ final class PlayerViewController: UIViewController {
         viewModel.didTapRewind()
     }
     
+    @objc private func didTapSpeedButton() {
+        viewModel.togglePlaybackSpeed()
+    }
+    
     // MARK: - Bindings
     private func setupBindings() {
         guard let customView = customView else { return }
@@ -76,6 +81,7 @@ final class PlayerViewController: UIViewController {
         bindPlayerState(to: customView)
         bindPlayerProgress(to: customView)
         bindTimeLabels(to: customView)
+        bindPlaybackSpeed(to: customView)
     }
     
     private func bindHeaderData(to view: PlayerView) {
@@ -126,6 +132,18 @@ final class PlayerViewController: UIViewController {
             .sink { [weak view] (current, total) in
                 view?.currentTimeLabel.text = current
                 view?.totalTimeLabel.text = total
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func bindPlaybackSpeed(to view: PlayerView) {
+        viewModel.$playbackSpeedLabel
+            .receive(on: DispatchQueue.main)
+            .sink { [weak view] text in
+                UIView.performWithoutAnimation {
+                    view?.speedButton.setTitle(text, for: .normal)
+                    view?.speedButton.layoutIfNeeded()
+                }
             }
             .store(in: &cancellables)
     }


### PR DESCRIPTION
## 📝 Summary
This PR introduces the **Playback Speed Control** feature, allowing users to toggle between 1.0x, 1.5x, and 2.0x speeds. It also implements dynamic time calculation, where the "Time Remaining" and "Current Time" labels update to reflect the perceived duration based on the selected speed.

## 🚀 Key Changes

### 🧠 Core & Logic
- **AudioPlayerService:** - Added `setPlaybackRate(_ rate: Float)` method.
    - Configured `AVPlayerItem.audioTimePitchAlgorithm = .timeDomain` to prevent pitch distortion (chipmunk effect) when speeding up audio.
    - Added `playbackRatePublisher` to broadcast state changes.
- **PlayerViewModel:** - Implemented `togglePlaybackSpeed()` logic (cycles: 1.0 -> 1.5 -> 2.0 -> 1.0).
    - Added `updateTimeDisplay()` logic to recalculate `currentTime` and `duration` strings based on the active rate (e.g., a 10m episode at 2.0x shows 05:00).

### 🎨 User Interface (View Code)
- **PlayerView:** - Added a new `speedButton` styled as a "chip" (rounded, small).
    - **Layout Fix:** Wrapped `speedButton` in a `speedContainerView` to prevent `UIStackView` from stretching it horizontally.
    - **Layout Fix:** Enforced strict height/width constraints on `playPauseButton` to ensure it remains a perfect circle.
    - Refactored `setupUI` to centralize all constraints, removing logic from lazy properties.
- **PlayerViewController:** - Connected new bindings for speed label updates.
    - Added target-action for the speed toggle.

## 🧪 How to Test
1. **Play:** Start an episode.
2. **Toggle Speed:** Tap the "1.0x" button. It should cycle to "1.5x" and "2.0x".
3. **Verify Audio:** Ensure the voice speeds up *without* changing pitch (no distortion).
4. **Verify Time:** - At 2.0x, the "Total Duration" label should display half of the original time.
    - Verify that the layout remains stable (Play button round, Speed button centered).
