### PR TITLE
[Feature] Offline Downloads & Persistence Refactor

### DIFF
--- a/Spokast/Core/Audio/AudioPlayerService.swift
+++ b/Spokast/Core/Audio/AudioPlayerService.swift
@@ -181,7 +181,6 @@ final class AudioPlayerService: AudioPlayerServiceProtocol {
         
         do {
             try persistence.save(checkpoint: checkpoint)
-            print("💾 Checkpoint saved at \(Int(currentTime))s")
         } catch {
             print("❌ Failed to save checkpoint: \(error)")
         }
@@ -190,11 +189,8 @@ final class AudioPlayerService: AudioPlayerServiceProtocol {
     // MARK: - Restoration Logic
     func restoreLastState() {
         guard let checkpoint = persistence.load() else {
-            print("💾 No playback checkpoint found.")
             return
         }
-        
-        print("💾 Restoring checkpoint: \(checkpoint.podcastTitle) at \(Int(checkpoint.timestamp))s")
         
         self.currentEpisode = checkpoint.episode
         self.currentPodcastImageURL = checkpoint.podcastArtWorkURL

--- a/Spokast/Core/Download /DownloadService.swift
+++ b/Spokast/Core/Download /DownloadService.swift
@@ -1,0 +1,128 @@
+//
+//  DownloadService.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 07/01/26.
+//
+
+import Foundation
+import Combine
+
+final class DownloadService: NSObject, DownloadServiceProtocol {
+    
+    // MARK: - Properties
+    var activeDownloadsPublisher = CurrentValueSubject<[URL: DownloadStatus], Never>([:])
+    private lazy var session: URLSession = {
+        let config = URLSessionConfiguration.default
+        return URLSession(configuration: config, delegate: self, delegateQueue: nil)
+    }()
+    
+    private var activeTasks: [URL: URLSessionDownloadTask] = [:]
+    private let fileManager = FileManager.default
+    
+    // MARK: - DownloadServiceProtocol
+    func startDownload(for episode: Episode) {
+        guard let url = episode.streamUrl else { return }
+        
+        if hasLocalFile(for: episode) != nil {
+            updateStatus(.downloaded(localURL: localFilePath(for: url)), for: url)
+            return
+        }
+        
+        if activeTasks[url] != nil { return }
+        
+        let task = session.downloadTask(with: url)
+        activeTasks[url] = task
+        task.resume()
+        
+        updateStatus(.downloading(progress: 0.0), for: url)
+    }
+    
+    func cancelDownload(for episode: Episode) {
+        guard let url = episode.streamUrl else { return }
+        
+        activeTasks[url]?.cancel()
+        activeTasks[url] = nil
+        
+        updateStatus(.notDownloaded, for: url)
+    }
+    
+    func hasLocalFile(for episode: Episode) -> URL? {
+        guard let url = episode.streamUrl else { return nil }
+        let localURL = localFilePath(for: url)
+        return fileManager.fileExists(atPath: localURL.path) ? localURL : nil
+    }
+    
+    func deleteLocalFile(for episode: Episode) {
+        guard let url = episode.streamUrl else { return }
+        
+        let localURL = localFilePath(for: url)
+        do {
+            if fileManager.fileExists(atPath: localURL.path) {
+                try fileManager.removeItem(at: localURL)
+                print("🗑️ Deleted local file: \(localURL.lastPathComponent)")
+            }
+            updateStatus(.notDownloaded, for: url)
+        } catch {
+            print("❌ Error deleting file: \(error)")
+        }
+    }
+    
+    // MARK: - Helper Methods
+    private func updateStatus(_ status: DownloadStatus, for url: URL) {
+        var current = activeDownloadsPublisher.value
+        current[url] = status
+        activeDownloadsPublisher.send(current)
+    }
+    
+    private func localFilePath(for url: URL) -> URL {
+        let documentsPath = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        return documentsPath.appendingPathComponent(url.lastPathComponent)
+    }
+}
+
+// MARK: - URLSessionDownloadDelegate
+
+extension DownloadService: URLSessionDownloadDelegate {
+    
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
+        guard let url = downloadTask.originalRequest?.url else { return }
+        
+        let progress = Float(totalBytesWritten) / Float(totalBytesExpectedToWrite)
+        updateStatus(.downloading(progress: progress), for: url)
+    }
+    
+    func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
+        guard let sourceURL = downloadTask.originalRequest?.url else { return }
+        let destinationURL = localFilePath(for: sourceURL)
+        
+        do {
+            try? fileManager.removeItem(at: destinationURL)
+            
+            try fileManager.moveItem(at: location, to: destinationURL)
+            
+            print("✅ Download finished: \(destinationURL.lastPathComponent)")
+            activeTasks[sourceURL] = nil
+            updateStatus(.downloaded(localURL: destinationURL), for: sourceURL)
+            
+        } catch {
+            print("❌ File Move Error: \(error)")
+            updateStatus(.failed(error: error), for: sourceURL)
+        }
+    }
+    
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        guard let url = task.originalRequest?.url else { return }
+        
+        activeTasks[url] = nil
+        
+        if let error = error {
+            if (error as NSError).code == NSURLErrorCancelled {
+                updateStatus(.notDownloaded, for: url)
+            } else {
+                print("❌ Download Error: \(error.localizedDescription)")
+                updateStatus(.failed(error: error), for: url)
+            }
+        }
+    }
+}

--- a/Spokast/Core/Download /DownloadServiceProtocol.swift
+++ b/Spokast/Core/Download /DownloadServiceProtocol.swift
@@ -1,0 +1,24 @@
+//
+//  DownloadServiceProtocol.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 07/01/26.
+//
+
+import Foundation
+import Combine
+
+enum DownloadStatus {
+    case notDownloaded
+    case downloading(progress: Float)
+    case downloaded(localURL: URL)
+    case failed(error: Error)
+}
+
+protocol DownloadServiceProtocol {
+    var activeDownloadsPublisher: CurrentValueSubject<[URL: DownloadStatus], Never> { get }
+    func startDownload(for episode: Episode)
+    func cancelDownload(for episode: Episode)
+    func hasLocalFile(for episode: Episode) -> URL?
+    func deleteLocalFile(for episode: Episode)
+}

--- a/Spokast/Core/Navigation/MainTabBarController.swift
+++ b/Spokast/Core/Navigation/MainTabBarController.swift
@@ -78,7 +78,6 @@ final class MainTabBarController: UITabBarController {
     
     private func presentPlayer() {
         guard let currentEpisode = AudioPlayerService.shared.currentEpisode else {
-            print("⚠️ Nenhum episódio selecionado no AudioService")
             return
         }
         

--- a/Spokast/Core/Persistence/DownloadPersistence.swift
+++ b/Spokast/Core/Persistence/DownloadPersistence.swift
@@ -1,0 +1,51 @@
+//
+//  DownloadPersistence.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 07/01/26.
+//
+
+import Foundation
+
+protocol DownloadPersistenceProtocol {
+    func saveDownloadedEpisode(_ episodeUrl: URL)
+    func removeDownloadedEpisode(_ episodeUrl: URL)
+    func getDownloadedEpisodes() -> Set<URL>
+}
+
+final class DownloadPersistence: DownloadPersistenceProtocol {
+    
+    private let key = "com.spokast.downloaded_episodes"
+    private let userDefaults: UserDefaults
+    
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+    
+    func saveDownloadedEpisode(_ episodeUrl: URL) {
+        var current = getDownloadedEpisodes()
+        current.insert(episodeUrl)
+        save(current)
+    }
+    
+    func removeDownloadedEpisode(_ episodeUrl: URL) {
+        var current = getDownloadedEpisodes()
+        current.remove(episodeUrl)
+        save(current)
+    }
+    
+    func getDownloadedEpisodes() -> Set<URL> {
+        guard let data = userDefaults.data(forKey: key),
+              let decoded = try? JSONDecoder().decode([URL].self, from: data) else {
+            return []
+        }
+        return Set(decoded)
+    }
+    
+    private func save(_ episodes: Set<URL>) {
+        let array = Array(episodes)
+        if let encoded = try? JSONEncoder().encode(array) {
+            userDefaults.set(encoded, forKey: key)
+        }
+    }
+}

--- a/Spokast/DownloadButton.swift
+++ b/Spokast/DownloadButton.swift
@@ -36,19 +36,26 @@ final class DownloadButton: UIButton {
     
     // MARK: - Lifecycle
     override func layoutSubviews() {
-        super.layoutSubviews()
-        let centerPoint = CGPoint(x: bounds.width / 2, y: bounds.height / 2)
-        let circularPath = UIBezierPath(
-            arcCenter: centerPoint,
-            radius: (bounds.width / 2) - 2,
-            startAngle: -CGFloat.pi / 2,
-            endAngle: 2 * CGFloat.pi - CGFloat.pi / 2,
-            clockwise: true
-        )
-        
-        trackLayer.path = circularPath.cgPath
-        progressLayer.path = circularPath.cgPath
-    }
+            super.layoutSubviews()
+            
+            let centerPoint = CGPoint(x: bounds.width / 2, y: bounds.height / 2)
+            
+            let smallestDimension = min(bounds.width, bounds.height)
+            let radius = (smallestDimension / 2) - 2
+            
+            let circularPath = UIBezierPath(
+                arcCenter: centerPoint,
+                radius: radius,
+                startAngle: -CGFloat.pi / 2,
+                endAngle: 2 * CGFloat.pi - CGFloat.pi / 2,
+                clockwise: true
+            )
+            
+            trackLayer.path = circularPath.cgPath
+            progressLayer.path = circularPath.cgPath
+            trackLayer.frame = bounds
+            progressLayer.frame = bounds
+        }
     
     // MARK: - Public API
     func updateState(_ state: State) {

--- a/Spokast/DownloadButton.swift
+++ b/Spokast/DownloadButton.swift
@@ -1,0 +1,121 @@
+//
+//  DownloadButton.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 07/01/26.
+//
+
+import Foundation
+import UIKit
+
+final class DownloadButton: UIButton {
+    
+    // MARK: - Enums
+    enum State {
+        case notDownloaded
+        case downloading(progress: Float)
+        case downloaded
+    }
+    
+    // MARK: - UI Layers
+    private let progressLayer = CAShapeLayer()
+    private let trackLayer = CAShapeLayer()
+    
+    // MARK: - Initialization
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+        setupLayers()
+        updateState(.notDownloaded)
+    }
+    
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Lifecycle
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        let centerPoint = CGPoint(x: bounds.width / 2, y: bounds.height / 2)
+        let circularPath = UIBezierPath(
+            arcCenter: centerPoint,
+            radius: (bounds.width / 2) - 2,
+            startAngle: -CGFloat.pi / 2,
+            endAngle: 2 * CGFloat.pi - CGFloat.pi / 2,
+            clockwise: true
+        )
+        
+        trackLayer.path = circularPath.cgPath
+        progressLayer.path = circularPath.cgPath
+    }
+    
+    // MARK: - Public API
+    func updateState(_ state: State) {
+            resetVisualState()
+            
+            switch state {
+            case .notDownloaded:
+                setupNotDownloaded()
+                
+            case .downloading(let progress):
+                setupDownloading(progress: progress)
+                
+            case .downloaded:
+                setupDownloaded()
+            }
+        }
+        
+    // MARK: - Private Helpers
+    private func resetVisualState() {
+        trackLayer.isHidden = true
+        progressLayer.isHidden = true
+        progressLayer.strokeEnd = 0
+        imageView?.layer.removeAllAnimations()
+    }
+    
+    private func setupNotDownloaded() {
+        setButtonIcon(name: "arrow.down.circle", color: .label)
+    }
+    
+    private func setupDownloading(progress: Float) {
+        setButtonIcon(name: "stop.fill", color: .systemPurple)
+        
+        trackLayer.isHidden = false
+        progressLayer.isHidden = false
+        progressLayer.strokeEnd = CGFloat(progress)
+    }
+    
+    private func setupDownloaded() {
+        setButtonIcon(name: "checkmark.circle.fill", color: .systemGreen)
+    }
+    
+    private func setButtonIcon(name: String, color: UIColor) {
+        let config = UIImage.SymbolConfiguration(pointSize: 20, weight: .medium)
+        let image = UIImage(systemName: name, withConfiguration: config)
+        setImage(image, for: .normal)
+        tintColor = color
+    }
+    
+    // MARK: - Setup
+    private func setupLayers() {
+        trackLayer.strokeColor = UIColor.systemGray5.cgColor
+        trackLayer.lineWidth = 3
+        trackLayer.fillColor = UIColor.clear.cgColor
+        trackLayer.lineCap = .round
+        layer.addSublayer(trackLayer)
+        
+        progressLayer.strokeColor = UIColor.systemPurple.cgColor
+        progressLayer.lineWidth = 3
+        progressLayer.fillColor = UIColor.clear.cgColor
+        progressLayer.lineCap = .round
+        progressLayer.strokeEnd = 0
+        layer.addSublayer(progressLayer)
+    }
+    
+    private func setupView() {
+        backgroundColor = .secondarySystemBackground
+        layer.cornerRadius = 8
+        clipsToBounds = true
+    }
+}

--- a/Spokast/Extensions/UI/UIViewController+Extensions.swift
+++ b/Spokast/Extensions/UI/UIViewController+Extensions.swift
@@ -1,0 +1,40 @@
+//
+//  UIViewController+Extensions.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 09/01/26.
+//
+
+import Foundation
+import UIKit
+
+extension UIViewController {
+    
+    func presentDeleteConfirmation(for episode: Episode, sourceView: UIView?, onConfirm: @escaping () -> Void) {
+        let alert = UIAlertController(
+            title: "Remove Download?",
+            message: "The episode \"\(episode.trackName)\" will be deleted from your device.",
+            preferredStyle: .actionSheet
+        )
+        
+        let deleteAction = UIAlertAction(title: "Remove Download", style: .destructive) { _ in
+            onConfirm()
+        }
+        
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
+        
+        alert.addAction(deleteAction)
+        alert.addAction(cancelAction)
+        
+        if let popover = alert.popoverPresentationController, let sourceView = sourceView {
+            popover.sourceView = sourceView
+            popover.sourceRect = sourceView.bounds
+        } else if let popover = alert.popoverPresentationController {
+            popover.sourceView = self.view
+            popover.sourceRect = CGRect(x: self.view.bounds.midX, y: self.view.bounds.midY, width: 0, height: 0)
+            popover.permittedArrowDirections = []
+        }
+        
+        present(alert, animated: true)
+    }
+}

--- a/Spokast/Features/Player/ViewModels/PlayerViewModel.swift
+++ b/Spokast/Features/Player/ViewModels/PlayerViewModel.swift
@@ -34,6 +34,10 @@ final class PlayerViewModel {
     @Published private(set) var durationText: String = "00:00"
     @Published var playbackSpeedLabel: String = "1.0x"
     @Published var downloadState: DownloadButton.State = .notDownloaded
+    
+    var currentEpisode: Episode? {
+        return audioPlayerService.currentEpisode
+    }
 
     
     // MARK: - Initialization
@@ -186,12 +190,10 @@ final class PlayerViewModel {
     
     private func getPlayableURL() -> URL? {
         if let localURL = downloadService.hasLocalFile(for: episode) {
-            print("🎧 Playing from LOCAL FILE: \(localURL.lastPathComponent)")
             return localURL
         }
         
         if let remoteURL = episode.streamUrl {
-            print("📡 Playing from REMOTE STREAM")
             return remoteURL
         }
         

--- a/Spokast/Features/Player/Views/PlayerView.swift
+++ b/Spokast/Features/Player/Views/PlayerView.swift
@@ -130,6 +130,12 @@ final class PlayerView: UIView {
         return button
     }()
     
+    let downloadButton: DownloadButton = {
+        let button = DownloadButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+    
     private lazy var controlsStackView: UIStackView = {
         let stack = UIStackView(arrangedSubviews: [rewindButton, playPauseButton, forwardButton])
         stack.translatesAutoresizingMaskIntoConstraints = false
@@ -140,11 +146,15 @@ final class PlayerView: UIView {
         return stack
     }()
     
-    private lazy var speedContainerView: UIView = {
-        let view = UIView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(speedButton)
-        return view
+    private lazy var buttomStackView: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [speedButton, downloadButton])
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .horizontal
+        stack.alignment = .center
+        stack.distribution = .equalCentering
+        stack.isLayoutMarginsRelativeArrangement = true
+        stack.layoutMargins = UIEdgeInsets(top: 0, left: 40, bottom: 0, right: 40)
+        return stack
     }()
 
     private lazy var mainStackView: UIStackView = {
@@ -155,7 +165,7 @@ final class PlayerView: UIView {
             progressSlider,
             timeStackView,
             controlsStackView,
-            speedContainerView
+            buttomStackView
         ])
         stack.translatesAutoresizingMaskIntoConstraints = false
         stack.axis = .vertical
@@ -203,11 +213,11 @@ final class PlayerView: UIView {
             
             coverContainerView.heightAnchor.constraint(equalTo: coverContainerView.widthAnchor),
             
-            speedButton.centerXAnchor.constraint(equalTo: speedContainerView.centerXAnchor),
-            speedButton.topAnchor.constraint(equalTo: speedContainerView.topAnchor),
-            speedButton.bottomAnchor.constraint(equalTo: speedContainerView.bottomAnchor),
             speedButton.heightAnchor.constraint(equalToConstant: 36),
             speedButton.widthAnchor.constraint(equalToConstant: 100),
+            
+            downloadButton.heightAnchor.constraint(equalToConstant: 36),
+            downloadButton.widthAnchor.constraint(equalToConstant: 100),
             
             coverImageView.topAnchor.constraint(equalTo: coverContainerView.topAnchor),
             coverImageView.leadingAnchor.constraint(equalTo: coverContainerView.leadingAnchor),

--- a/Spokast/Features/Player/Views/PlayerViewController.swift
+++ b/Spokast/Features/Player/Views/PlayerViewController.swift
@@ -157,4 +157,37 @@ final class PlayerViewController: UIViewController {
             }
             .store(in: &cancellables)
     }
+    
+    private func bindDownloadState(to view: PlayerView) {
+        viewModel.$downloadState
+            .receive(on: DispatchQueue.main)
+            .sink { [weak view] state in
+                view?.downloadButton.updateState(state)
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func showDeleteConfirmation() {
+        let alert = UIAlertController(
+            title: "Remove Download",
+            message: "Do you want to remove this episode from your device?",
+            preferredStyle: .actionSheet
+        )
+        
+        let deleteAction = UIAlertAction(title: "Remove Download", style: .destructive) { [weak self] _ in
+            self?.viewModel.deleteDownloadedEpisode()
+        }
+        
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
+        
+        alert.addAction(deleteAction)
+        alert.addAction(cancelAction)
+        
+        if let popover = alert.popoverPresentationController, let customView = customView {
+            popover.sourceView = customView.downloadButton
+            popover.sourceRect = customView.downloadButton.bounds
+        }
+        
+        present(alert, animated: true)
+    }
 }

--- a/Spokast/Features/Player/Views/PlayerViewController.swift
+++ b/Spokast/Features/Player/Views/PlayerViewController.swift
@@ -75,7 +75,11 @@ final class PlayerViewController: UIViewController {
     
     @objc private func didTapDownload() {
         if case .downloaded = viewModel.downloadState {
-            showDeleteConfirmation()
+            if let episode = viewModel.currentEpisode {
+                presentDeleteConfirmation(for: episode, sourceView: customView?.downloadButton) { [weak self] in
+                    self?.viewModel.deleteDownloadedEpisode()
+                }
+            }
         } else {
             viewModel.didTapDownload()
         }
@@ -165,29 +169,5 @@ final class PlayerViewController: UIViewController {
                 view?.downloadButton.updateState(state)
             }
             .store(in: &cancellables)
-    }
-    
-    private func showDeleteConfirmation() {
-        let alert = UIAlertController(
-            title: "Remove Download",
-            message: "Do you want to remove this episode from your device?",
-            preferredStyle: .actionSheet
-        )
-        
-        let deleteAction = UIAlertAction(title: "Remove Download", style: .destructive) { [weak self] _ in
-            self?.viewModel.deleteDownloadedEpisode()
-        }
-        
-        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
-        
-        alert.addAction(deleteAction)
-        alert.addAction(cancelAction)
-        
-        if let popover = alert.popoverPresentationController, let customView = customView {
-            popover.sourceView = customView.downloadButton
-            popover.sourceRect = customView.downloadButton.bounds
-        }
-        
-        present(alert, animated: true)
     }
 }

--- a/Spokast/Features/Player/Views/PlayerViewController.swift
+++ b/Spokast/Features/Player/Views/PlayerViewController.swift
@@ -49,6 +49,7 @@ final class PlayerViewController: UIViewController {
         customView.rewindButton.addTarget(self, action: #selector(didTapRewind), for: .touchUpInside)
         customView.progressSlider.addTarget(self, action: #selector(didScrubSlider(_:)), for: .valueChanged)
         customView.speedButton.addTarget(self, action: #selector(didTapSpeedButton), for: .touchUpInside)
+        customView.downloadButton.addTarget(self, action: #selector(didTapDownload), for: .touchUpInside)
     }
     
     @objc private func didScrubSlider(_ sender: UISlider) {
@@ -72,6 +73,14 @@ final class PlayerViewController: UIViewController {
         viewModel.togglePlaybackSpeed()
     }
     
+    @objc private func didTapDownload() {
+        if case .downloaded = viewModel.downloadState {
+            showDeleteConfirmation()
+        } else {
+            viewModel.didTapDownload()
+        }
+    }
+    
     // MARK: - Bindings
     private func setupBindings() {
         guard let customView = customView else { return }
@@ -82,6 +91,7 @@ final class PlayerViewController: UIViewController {
         bindPlayerProgress(to: customView)
         bindTimeLabels(to: customView)
         bindPlaybackSpeed(to: customView)
+        bindDownloadState(to: customView)
     }
     
     private func bindHeaderData(to view: PlayerView) {

--- a/Spokast/Features/PodcastDetail/Views/Cells/EpisodeCell.swift
+++ b/Spokast/Features/PodcastDetail/Views/Cells/EpisodeCell.swift
@@ -15,6 +15,7 @@ final class EpisodeCell: UITableViewCell {
     
     // MARK: - Actions
     var onPlayTap: (() -> Void)?
+    var didTapDownloadAction: (() -> Void)?
     
     // MARK: - UI Components
     private lazy var artworkContainer: UIView = {
@@ -68,6 +69,13 @@ final class EpisodeCell: UITableViewCell {
         return label
     }()
     
+    let downloadButton: DownloadButton = {
+        let button = DownloadButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setContentCompressionResistancePriority(.required, for: .horizontal)
+        return button
+    }()
+    
     private lazy var textStackView: UIStackView = {
         let stack = UIStackView(arrangedSubviews: [titleLabel, descriptionLabel])
         stack.translatesAutoresizingMaskIntoConstraints = false
@@ -82,6 +90,7 @@ final class EpisodeCell: UITableViewCell {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setupUI()
         setupGestures()
+        setupActions()
     }
     
     @available(*, unavailable)
@@ -94,10 +103,12 @@ final class EpisodeCell: UITableViewCell {
         super.prepareForReuse()
         artworkImageView.kf.cancelDownloadTask()
         artworkImageView.image = nil
+        didTapDownloadAction = nil
+        downloadButton.updateState(.notDownloaded)
     }
     
     // MARK: - Configuration
-    func configure(with episode: Episode, podcastArtURL: URL?, isPlaying: Bool) {
+    func configure(with episode: Episode, downloadStatus: DownloadButton.State,  podcastArtURL: URL?, isPlaying: Bool) {
         titleLabel.text = episode.trackName
         
         let dateFormatter = DateFormatter()
@@ -116,6 +127,7 @@ final class EpisodeCell: UITableViewCell {
         )
         
         updatePlaybackState(isPlaying: isPlaying)
+        downloadButton.updateState(downloadStatus)
     }
     
     // MARK: - Helpers
@@ -145,6 +157,11 @@ final class EpisodeCell: UITableViewCell {
     private func setupGestures() {
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(didTapPlayContainer))
         artworkContainer.addGestureRecognizer(tapGesture)
+        artworkContainer.isUserInteractionEnabled = true
+    }
+    
+    private func setupActions() {
+        downloadButton.addTarget(self, action: #selector(didTapDownload), for: .touchUpInside)
     }
     
     @objc private func didTapPlayContainer() {
@@ -158,6 +175,10 @@ final class EpisodeCell: UITableViewCell {
         onPlayTap?()
     }
     
+    @objc private func didTapDownload() {
+        didTapDownloadAction?()
+    }
+    
     // MARK: - UI Setup
     private func setupUI() {
         backgroundColor = .systemBackground
@@ -169,6 +190,7 @@ final class EpisodeCell: UITableViewCell {
         artworkContainer.addSubview(playImageView)
         
         contentView.addSubview(textStackView)
+        contentView.addSubview(downloadButton)
         
         NSLayoutConstraint.activate([
             artworkContainer.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
@@ -192,10 +214,15 @@ final class EpisodeCell: UITableViewCell {
             playImageView.widthAnchor.constraint(equalToConstant: 24),
             
             textStackView.leadingAnchor.constraint(equalTo: artworkContainer.trailingAnchor, constant: 16),
-            textStackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            textStackView.trailingAnchor.constraint(equalTo: downloadButton.leadingAnchor, constant: -16),
             textStackView.centerYAnchor.constraint(equalTo: artworkContainer.centerYAnchor),
             textStackView.topAnchor.constraint(greaterThanOrEqualTo: contentView.topAnchor, constant: 10),
-            textStackView.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: -10)
+            textStackView.bottomAnchor.constraint(lessThanOrEqualTo: contentView.bottomAnchor, constant: -10),
+            
+            downloadButton.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            downloadButton.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            downloadButton.heightAnchor.constraint(equalToConstant: 32),
+            downloadButton.widthAnchor.constraint(equalToConstant: 32),
         ])
     }
 }

--- a/Spokast/UIComponents/DownloadButton.swift
+++ b/Spokast/UIComponents/DownloadButton.swift
@@ -20,6 +20,7 @@ final class DownloadButton: UIButton {
     // MARK: - UI Layers
     private let progressLayer = CAShapeLayer()
     private let trackLayer = CAShapeLayer()
+    private let checkmarkLayer = CAShapeLayer() // 1. Nova Layer
     
     // MARK: - Initialization
     override init(frame: CGRect) {
@@ -36,53 +37,63 @@ final class DownloadButton: UIButton {
     
     // MARK: - Lifecycle
     override func layoutSubviews() {
-            super.layoutSubviews()
-            
-            let centerPoint = CGPoint(x: bounds.width / 2, y: bounds.height / 2)
-            
-            let smallestDimension = min(bounds.width, bounds.height)
-            let radius = (smallestDimension / 2) - 2
-            
-            let circularPath = UIBezierPath(
-                arcCenter: centerPoint,
-                radius: radius,
-                startAngle: -CGFloat.pi / 2,
-                endAngle: 2 * CGFloat.pi - CGFloat.pi / 2,
-                clockwise: true
-            )
-            
-            trackLayer.path = circularPath.cgPath
-            progressLayer.path = circularPath.cgPath
-            trackLayer.frame = bounds
-            progressLayer.frame = bounds
-        }
+        super.layoutSubviews()
+        
+        let centerPoint = CGPoint(x: bounds.width / 2, y: bounds.height / 2)
+        let smallestDimension = min(bounds.width, bounds.height)
+        let radius = (smallestDimension / 2) - 2
+        
+        let circularPath = UIBezierPath(
+            arcCenter: centerPoint,
+            radius: radius,
+            startAngle: -CGFloat.pi / 2,
+            endAngle: 2 * CGFloat.pi - CGFloat.pi / 2,
+            clockwise: true
+        )
+        
+        trackLayer.path = circularPath.cgPath
+        progressLayer.path = circularPath.cgPath
+        trackLayer.frame = bounds
+        progressLayer.frame = bounds
+        
+        let checkPath = UIBezierPath()
+        checkPath.move(to: CGPoint(x: bounds.width * 0.35, y: bounds.height * 0.5))
+        checkPath.addLine(to: CGPoint(x: bounds.width * 0.45, y: bounds.height * 0.65))
+        checkPath.addLine(to: CGPoint(x: bounds.width * 0.70, y: bounds.height * 0.35))
+        
+        checkmarkLayer.path = checkPath.cgPath
+        checkmarkLayer.frame = bounds
+    }
     
     // MARK: - Public API
     func updateState(_ state: State) {
-            resetVisualState()
+        resetVisualState()
+        
+        switch state {
+        case .notDownloaded:
+            progressLayer.isHidden = true
+            checkmarkLayer.isHidden = true
+            setupNotDownloaded()
             
-            switch state {
-            case .notDownloaded:
-                setupNotDownloaded()
-                
-            case .downloading(let progress):
-                setupDownloading(progress: progress)
-                
-            case .downloaded:
-                setupDownloaded()
-            }
+        case .downloading(let progress):
+            setupDownloading(progress: progress)
+            
+        case .downloaded:
+            setupDownloaded()
         }
+    }
         
     // MARK: - Private Helpers
     private func resetVisualState() {
         trackLayer.isHidden = true
         progressLayer.isHidden = true
+        checkmarkLayer.isHidden = true
         progressLayer.strokeEnd = 0
         imageView?.layer.removeAllAnimations()
     }
     
     private func setupNotDownloaded() {
-        setButtonIcon(name: "arrow.down.circle", color: .label)
+        setButtonIcon(name: "arrow.down", color: .label)
     }
     
     private func setupDownloading(progress: Float) {
@@ -90,15 +101,19 @@ final class DownloadButton: UIButton {
         
         trackLayer.isHidden = false
         progressLayer.isHidden = false
+        checkmarkLayer.isHidden = true
         progressLayer.strokeEnd = CGFloat(progress)
     }
     
     private func setupDownloaded() {
-        setButtonIcon(name: "checkmark.circle.fill", color: .systemGreen)
+        setImage(nil, for: .normal)
+        trackLayer.isHidden = true
+        progressLayer.isHidden = true
+        checkmarkLayer.isHidden = false
     }
     
     private func setButtonIcon(name: String, color: UIColor) {
-        let config = UIImage.SymbolConfiguration(pointSize: 20, weight: .medium)
+        let config = UIImage.SymbolConfiguration(pointSize: 18, weight: .bold)
         let image = UIImage(systemName: name, withConfiguration: config)
         setImage(image, for: .normal)
         tintColor = color
@@ -118,6 +133,14 @@ final class DownloadButton: UIButton {
         progressLayer.lineCap = .round
         progressLayer.strokeEnd = 0
         layer.addSublayer(progressLayer)
+        
+        checkmarkLayer.strokeColor = UIColor.systemGreen.cgColor
+        checkmarkLayer.lineWidth = 3
+        checkmarkLayer.fillColor = UIColor.clear.cgColor
+        checkmarkLayer.lineCap = .round
+        checkmarkLayer.lineJoin = .round
+        checkmarkLayer.isHidden = true
+        layer.addSublayer(checkmarkLayer)
     }
     
     private func setupView() {


### PR DESCRIPTION
## 🚀 What has been done?
Complete implementation of the offline downloads feature, allowing users to download episodes, visualize progress, and manage local storage.

## 🛠️ Key Technical Changes
1. **Refactored DownloadService:**
   - Fixed a critical bug where all files were being saved as `default.mp3`. We now use a hash of the full URL to guarantee filename uniqueness.
2. **Code Reuse (DRY):**
   - Created `UIViewController+Extensions` to centralize the Delete Alert logic, removing duplicated code from `PodcastDetailViewController` and `PlayerViewController`.
3. **UI & UX:**
   - Adjusted `EpisodeCell` constraints to prevent text from overlapping the download button.
   - Implemented a Vector Checkmark in `DownloadButton` for better sharpness and scalability.
   - Standardized alert texts to English.
4. **Performance:**
   - Optimized UI updates during downloads (updating only visible cells instead of calling `reloadData`).

## 🐛 Bug Fixes
- **Ghost Checkmarks:** Fixed a cell reuse issue where "downloaded" icons appeared on the wrong episodes during scrolling.
- **File Collision:** Fixed a bug where the system incorrectly assumed all episodes were already downloaded due to filename conflicts.

## 🧪 How to Test
1. Open an episode list (e.g., NerdCast).
2. Tap to download an episode -> Verify the animation and checkmark persistence.
3. Scroll through the list -> Verify that the checkmark does not appear on other episodes (ghosting).
4. Attempt to download a second episode -> It should download correctly (creating distinct files).
5. Tap the checkmark -> It should trigger the Delete Alert (test both "Remove" and "Cancel" buttons).
6. Go to the Player -> The download button should reflect the correct state.