### PR TITLE
feat: Implement RSS Parsing for unlimited episodes & Performance improvements

### DIFF
--- a/Spokast/Application/AppDelegate.swift
+++ b/Spokast/Application/AppDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Kingfisher
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -13,7 +14,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+        setupImageCache()
         return true
     }
 
@@ -31,6 +32,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
 
+    func setupImageCache() {
+        ImageCache.default.memoryStorage.config.totalCostLimit = 50 * 1024 * 1024
+        ImageCache.default.memoryStorage.config.countLimit = 50
+        ImageCache.default.memoryStorage.config.expiration = .seconds(300)
+    }
 
 }
 

--- a/Spokast/Core/Data/Repositories/PodcastRepository.swift
+++ b/Spokast/Core/Data/Repositories/PodcastRepository.swift
@@ -35,7 +35,7 @@ final class PodcastRepository: PodcastRepositoryProtocol {
         let episodes = try await rssParser.parse(feedURL: feedUrl)
         
         let enrichedEpisodes = episodes.map { episode -> Episode in
-            var mutableEpisode = episode
+            let mutableEpisode = episode
             if mutableEpisode.artworkUrl600 == nil {
                 return Episode(
                     trackId: episode.trackId,

--- a/Spokast/Core/Data/Repositories/PodcastRepository.swift
+++ b/Spokast/Core/Data/Repositories/PodcastRepository.swift
@@ -1,0 +1,65 @@
+//
+//  PodcastRepository.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 12/01/26.
+//
+
+import Foundation
+
+protocol PodcastRepositoryProtocol {
+    func fetchEpisodes(for podcastId: Int) async throws -> [Episode]
+}
+
+final class PodcastRepository: PodcastRepositoryProtocol {
+    
+    // MARK: - Dependencies
+    private let apiService: APIServiceProtocol
+    private let rssParser: RSSParserServiceProtocol
+    
+    // MARK: - Initialization
+    init(apiService: APIServiceProtocol = APIService(),rssParser: RSSParserServiceProtocol = RSSParserService()) {
+        self.apiService = apiService
+        self.rssParser = rssParser
+    }
+    
+    // MARK: - Public API
+    func fetchEpisodes(for podcastId: Int) async throws -> [Episode] {
+        let podcast = try await fetchPodcastDetails(id: podcastId)
+        
+        guard let feedUrlString = podcast.feedUrl,
+              let feedUrl = URL(string: feedUrlString) else {
+            throw URLError(.resourceUnavailable)
+        }
+        
+        let episodes = try await rssParser.parse(feedURL: feedUrl)
+        
+        let enrichedEpisodes = episodes.map { episode -> Episode in
+            var mutableEpisode = episode
+            if mutableEpisode.artworkUrl600 == nil {
+                return Episode(
+                    trackId: episode.trackId,
+                    trackName: episode.trackName,
+                    description: episode.description,
+                    releaseDate: episode.releaseDate,
+                    trackTimeMillis: episode.trackTimeMillis,
+                    previewUrl: episode.previewUrl,
+                    episodeUrl: episode.episodeUrl,
+                    artworkUrl160: podcast.artworkUrl600,
+                    collectionName: podcast.collectionName,
+                    collectionId: podcastId,
+                    artworkUrl600: episode.artworkUrl600 ?? podcast.artworkUrl600,
+                    artistName: podcast.artistName
+                )
+            }
+            return mutableEpisode
+        }
+        
+        return enrichedEpisodes
+    }
+    
+    // MARK: - Private Helpers
+    private func fetchPodcastDetails(id: Int) async throws -> Podcast {
+        return try await apiService.fetchPodcastDetails(id: id)
+    }
+}

--- a/Spokast/Core/Networking/APIServiceProtocol.swift
+++ b/Spokast/Core/Networking/APIServiceProtocol.swift
@@ -17,4 +17,5 @@ enum APIError: Error {
 protocol APIServiceProtocol {
     func fetchPodcasts(searchTerm: String, limit: Int) async throws -> [Podcast]
     func fetchEpisodes(for podcastId: Int) async throws -> [Episode]
+    func fetchPodcastDetails(id: Int) async throws -> Podcast
 }

--- a/Spokast/Core/Services/Parser/RSSParserService.swift
+++ b/Spokast/Core/Services/Parser/RSSParserService.swift
@@ -1,0 +1,190 @@
+//
+//  RSSParserService.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 12/01/26.
+//
+
+import Foundation
+
+protocol RSSParserServiceProtocol {
+    func parse(feedURL: URL) async throws -> [Episode]
+}
+
+final class RSSParserService: NSObject, RSSParserServiceProtocol {
+    
+    // MARK: - Properties
+    private var parser: XMLParser?
+    private var episodes: [Episode] = []
+    private var currentParsingError: Error?
+    
+    private var currentElement = ""
+    private var currentTitle: String = ""
+    private var currentDescription: String = ""
+    private var currentPubDate: String = ""
+    private var currentStreamUrl: String = ""
+    private var currentDuration: String = ""
+    private var currentImage: String = ""
+    private var isInsideItem = false
+    private var continuation: CheckedContinuation<[Episode], Error>?
+    
+    // MARK: - Public API
+    func parse(feedURL: URL) async throws -> [Episode] {
+        return try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+            self.startParsing(url: feedURL)
+        }
+    }
+    
+    // MARK: - Private Setup
+    private func startParsing(url: URL) {
+        episodes = []
+        currentParsingError = nil
+        
+        let request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 30)
+        
+        let task = URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
+            guard let self = self else { return }
+            
+            if let error = error {
+                self.continuation?.resume(throwing: error)
+                self.continuation = nil
+                return
+            }
+            
+            guard let data = data else {
+                self.continuation?.resume(throwing: URLError(.badServerResponse))
+                self.continuation = nil
+                return
+            }
+            
+            self.parser = XMLParser(data: data)
+            self.parser?.delegate = self
+            self.parser?.parse()
+        }
+        task.resume()
+    }
+}
+
+// MARK: - XMLParserDelegate
+extension RSSParserService: XMLParserDelegate {
+    
+    func parser(_ parser: XMLParser, didStartElement elementName: String, namespaceURI: String?, qualifiedName qName: String?, attributes attributeDict: [String : String] = [:]) {
+        currentElement = elementName
+        
+        if elementName == "item" {
+            isInsideItem = true
+            currentTitle = ""
+            currentDescription = ""
+            currentPubDate = ""
+            currentStreamUrl = ""
+            currentDuration = ""
+            currentImage = ""
+        }
+        
+        if isInsideItem && elementName == "enclosure" {
+            if let url = attributeDict["url"] {
+                currentStreamUrl = url
+            }
+        }
+        
+        if isInsideItem && elementName == "itunes:duration" {
+            currentDuration = ""
+        }
+        
+        if isInsideItem && elementName == "itunes:image" {
+            if let href = attributeDict["href"] {
+                currentImage = href
+            }
+        }
+    }
+    
+    func parser(_ parser: XMLParser, foundCharacters string: String) {
+        guard isInsideItem else { return }
+        
+        let data = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        switch currentElement {
+        case "title":
+            currentTitle += string
+        case "description", "itunes:summary", "content:encoded":
+            currentDescription += string
+        case "pubDate":
+            currentPubDate += string
+        case "itunes:duration":
+            currentDuration += data
+        default:
+            break
+        }
+    }
+    
+    func parser(_ parser: XMLParser, didEndElement elementName: String, namespaceURI: String?, qualifiedName qName: String?) {
+        if elementName == "item" {
+            let episode = makeEpisode()
+            episodes.append(episode)
+            isInsideItem = false
+        }
+    }
+    
+    func parserDidEndDocument(_ parser: XMLParser) {
+        continuation?.resume(returning: episodes)
+        continuation = nil
+    }
+    
+    func parser(_ parser: XMLParser, parseErrorOccurred parseError: Error) {
+        continuation?.resume(throwing: parseError)
+        continuation = nil
+    }
+    
+    // MARK: - Helper Construction
+    private func makeEpisode() -> Episode {
+        let cleanTitle = currentTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "\n", with: "")
+        
+        let cleanDesc = currentDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+        
+        let formatter = DateFormatter()
+        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss Z"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        let date = formatter.date(from: currentPubDate) ?? Date()
+        
+        let uniqueID = abs(currentStreamUrl.hashValue)
+        
+        let durationMillis = parseDuration(currentDuration)
+        
+        return Episode(
+            trackId: uniqueID,
+            trackName: cleanTitle,
+            description: cleanDesc,
+            releaseDate: date,
+            trackTimeMillis: durationMillis,
+            previewUrl: nil,
+            episodeUrl: currentStreamUrl,
+            artworkUrl160: nil,
+            collectionName: nil,
+            collectionId: 0,
+            artworkUrl600: currentImage.isEmpty ? nil : currentImage,
+            artistName: nil
+        )
+    }
+    
+    private func parseDuration(_ durationString: String) -> Int? {
+        let components = durationString.components(separatedBy: ":")
+        var seconds = 0
+        
+        if components.count == 3 {
+            let hours = Int(components[0]) ?? 0
+            let minutes = Int(components[1]) ?? 0
+            let secs = Int(components[2]) ?? 0
+            seconds = (hours * 3600) + (minutes * 60) + secs
+        } else if components.count == 2 {
+            let minutes = Int(components[0]) ?? 0
+            let secs = Int(components[1]) ?? 0
+            seconds = (minutes * 60) + secs
+        } else {
+            seconds = Int(durationString) ?? 0
+        }
+        
+        return seconds * 1000
+    }
+}

--- a/Spokast/Features/Favorites/Coordinator/FavoritesCoordinator.swift
+++ b/Spokast/Features/Favorites/Coordinator/FavoritesCoordinator.swift
@@ -26,15 +26,8 @@ final class FavoritesCoordinator: Coordinator {
 
 extension FavoritesCoordinator: PodcastSelectionDelegate {
     func didSelectPodcast(_ podcast: Podcast) {
-        let service = APIService()
         let favoritesRepository = FavoritesRepository()
-        
-        let detailViewModel = PodcastDetailViewModel(
-            podcast: podcast,
-            service: service,
-            favoritesRepository: favoritesRepository
-        )
-        
+        let detailViewModel = PodcastDetailViewModel(podcast: podcast, favoritesRepository: favoritesRepository)
         let detailVC = PodcastDetailViewController(viewModel: detailViewModel)
         detailVC.coordinator = self
         navigationController.pushViewController(detailVC, animated: true)

--- a/Spokast/Features/Home/HomeCoordinator.swift
+++ b/Spokast/Features/Home/HomeCoordinator.swift
@@ -51,9 +51,8 @@ final class HomeCoordinator: Coordinator {
 // MARK: - HomeViewControllerDelegate
 extension HomeCoordinator: HomeViewControllerDelegate {
     func didSelectPodcast(_ podcast: Podcast) {
-        let service = APIService()
         let favoritesRepository = FavoritesRepository()
-        let detailViewModel = PodcastDetailViewModel(podcast: podcast, service: service, favoritesRepository: favoritesRepository)
+        let detailViewModel = PodcastDetailViewModel(podcast: podcast, favoritesRepository: favoritesRepository)
         let detailViewController = PodcastDetailViewController(viewModel: detailViewModel)
         detailViewController.coordinator = self
         navigationController.pushViewController(detailViewController, animated: true)

--- a/Spokast/Features/Search/Coordinator/SearchCoordinator.swift
+++ b/Spokast/Features/Search/Coordinator/SearchCoordinator.swift
@@ -39,15 +39,8 @@ final class SearchCoordinator: Coordinator {
 extension SearchCoordinator: PodcastSelectionDelegate {
     
     func didSelectPodcast(_ podcast: Podcast) {
-        let service = APIService()
         let favoritesRepository = FavoritesRepository()
-        
-        let detailViewModel = PodcastDetailViewModel(
-            podcast: podcast,
-            service: service,
-            favoritesRepository: favoritesRepository
-        )
-        
+        let detailViewModel = PodcastDetailViewModel(podcast: podcast, favoritesRepository: favoritesRepository)
         let detailVC = PodcastDetailViewController(viewModel: detailViewModel)
         detailVC.coordinator = self
         navigationController.pushViewController(detailVC, animated: true)


### PR DESCRIPTION
## Description

This PR removes the iTunes API limitation (which capped results at 50 episodes) by implementing a native XML Parser to read the original Podcast RSS feeds directly.

## Key Changes

* **Data Layer:** Replaced JSON episode fetching with XML Parsing (`RSSParserService`), allowing access to the podcast's full history.
* **Performance:** Implemented image Downsampling and Kingfisher cache limits to prevent memory spikes (>500MB) when scrolling through long lists.
* **UI/UX:** Refactored `PodcastDetailViewController` updates to ensure perfect synchronization between the Player state and the cell's Play/Pause button without reloading the entire table.
* **Fixes:** Adjusted unique ID generation (deterministic hash) and URL mapping to ensure compatibility with the existing Audio Player service.