### PR TITLE
feat(player): enable background playback and lock screen controls

### DIFF
--- a/Spokast/Info.plist
+++ b/Spokast/Info.plist
@@ -19,5 +19,9 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Description
This PR enables the app to continue playing audio while in the background and integrates with the native iOS system controls. Users can now control playback (Play/Pause/Skip) and view episode details (Title/Artwork/Progress) directly from the Lock Screen, Control Center, or Dynamic Island.

Key Changes
Audio Session: Configured AVAudioSession with .playback category to prevent audio suspension when the app is backgrounded.

Remote Commands: Implemented MPRemoteCommandCenter handlers for Play, Pause, SkipForward (30s), SkipBackward (15s), and Scrubber seeking.

Now Playing Info: Integrated MPNowPlayingInfoCenter to publish metadata.

Asynchronous artwork loading.

Precise playback duration and elapsed time syncing.

Bug Fix: Added a KVO Observer for AVPlayerItem.duration to fix a race condition where the progress bar would initially show 0:00 until the asset metadata was fully loaded.

How to Test
Play an episode.

Lock the device or minimize the app.

Verify audio continues playing.

Check the Lock Screen: Artwork and Title should appear, and the progress bar should move.

Use the Lock Screen buttons to Pause and Skip.