### PR TITLE
feat(persistence): add playback history via SwiftData & enforce strict concurrency

### DIFF
--- a/Spokast/Core/Data/Models/EpisodeProgress.swift
+++ b/Spokast/Core/Data/Models/EpisodeProgress.swift
@@ -1,0 +1,48 @@
+//
+//  EpisodeProgress.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 23/01/26.
+//
+import Foundation
+import SwiftData
+
+@Model
+final class EpisodeProgress {
+    
+    @Attribute(.unique) var episodeId: String
+    @Attribute(.externalStorage) var episodeData: Data?
+    
+    var podcastId: String?
+    var currentTime: Double
+    var duration: Double
+    var lastPlayedAt: Date
+    var isCompleted: Bool
+    var episodeTitle: String
+    var podcastTitle: String
+    var podcastArtWorkURLString: String?
+    
+    init(
+        episodeId: String,
+        podcastId: String? = nil,
+        currentTime: Double,
+        duration: Double,
+        lastPlayedAt: Date = Date(),
+        isCompleted: Bool = false,
+        episodeTitle: String,
+        podcastTitle: String,
+        podcastArtWorkURLString: String? = nil,
+        episodeData: Data? = nil
+    ) {
+        self.episodeId = episodeId
+        self.podcastId = podcastId
+        self.currentTime = currentTime
+        self.duration = duration
+        self.lastPlayedAt = lastPlayedAt
+        self.isCompleted = isCompleted
+        self.episodeTitle = episodeTitle
+        self.podcastTitle = podcastTitle
+        self.podcastArtWorkURLString = podcastArtWorkURLString
+        self.episodeData = episodeData
+    }
+}

--- a/Spokast/Core/Data/Services/SwiftDataPlaybackPersistence.swift
+++ b/Spokast/Core/Data/Services/SwiftDataPlaybackPersistence.swift
@@ -1,0 +1,90 @@
+//
+//  SwiftDataPlaybackPersistence.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 23/01/26.
+//
+
+import Foundation
+import SwiftData
+
+@MainActor
+final class SwiftDataPlaybackPersistence: PlaybackPersistenceProtocol {
+
+    private let container: ModelContainer
+    private let context: ModelContext
+    
+    init() {
+        do {
+            let schema = Schema([EpisodeProgress.self])
+            let modelConfiguration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
+            self.container = try ModelContainer(for: schema, configurations: [modelConfiguration])
+            self.context = container.mainContext
+        } catch {
+            fatalError("❌ Failed to initialize SwiftData container: \(error)")
+        }
+    }
+    
+    // MARK: - Save (Upsert Logic)
+    func save(checkpoint: PlaybackCheckpoint) throws {
+        let episodeId = String(checkpoint.episode.trackId)
+        
+        let encoder = JSONEncoder()
+        let episodeData = try? encoder.encode(checkpoint.episode)
+        
+        let descriptor = FetchDescriptor<EpisodeProgress>(
+            predicate: #Predicate { $0.episodeId == episodeId }
+        )
+        
+        let existingProgress = try context.fetch(descriptor).first
+        
+        if let progress = existingProgress {
+            progress.currentTime = checkpoint.timestamp
+            progress.lastPlayedAt = checkpoint.savedAt
+            progress.episodeData = episodeData
+        } else {
+            let newProgress = EpisodeProgress(
+                episodeId: episodeId,
+                podcastId: String(checkpoint.episode.collectionId),
+                currentTime: checkpoint.timestamp,
+                duration: checkpoint.episode.durationInSeconds,
+                lastPlayedAt: checkpoint.savedAt,
+                episodeTitle: checkpoint.episode.trackName,
+                podcastTitle: checkpoint.podcastTitle,
+                podcastArtWorkURLString: checkpoint.podcastArtWorkURL?.absoluteString,
+                episodeData: episodeData
+            )
+            context.insert(newProgress)
+        }
+    }
+    
+    // MARK: - Load Last Played
+    func load() -> PlaybackCheckpoint? {
+        var descriptor = FetchDescriptor<EpisodeProgress>(
+            sortBy: [SortDescriptor(\.lastPlayedAt, order: .reverse)]
+        )
+        descriptor.fetchLimit = 1
+        
+        guard let progress = try? context.fetch(descriptor).first,
+              let data = progress.episodeData else {
+            return nil
+        }
+        
+        let decoder = JSONDecoder()
+        guard let episode = try? decoder.decode(Episode.self, from: data) else {
+            return nil
+        }
+        
+        return PlaybackCheckpoint(
+            episode: episode,
+            podcastTitle: progress.podcastTitle,
+            podcastArtWorkURL: URL(string: progress.podcastArtWorkURLString ?? ""),
+            timestamp: progress.currentTime,
+            savedAt: progress.lastPlayedAt
+        )
+    }
+    
+    func clear() {
+        try? context.delete(model: EpisodeProgress.self)
+    }
+}

--- a/Spokast/Core/Persistence/PlaybackPersistenceProtocol.swift
+++ b/Spokast/Core/Persistence/PlaybackPersistenceProtocol.swift
@@ -15,6 +15,7 @@ struct PlaybackCheckpoint: Codable {
     let savedAt: Date
 }
 
+@MainActor
 protocol PlaybackPersistenceProtocol {
     func save(checkpoint: PlaybackCheckpoint) throws
     func load() -> PlaybackCheckpoint?

--- a/Spokast/Features/Player/ViewModels/MiniPlayerViewModel.swift
+++ b/Spokast/Features/Player/ViewModels/MiniPlayerViewModel.swift
@@ -24,8 +24,8 @@ final class MiniPlayerViewModel {
     private var cancellables = Set<AnyCancellable>()
     
     // MARK: - Init
-    init(service: AudioPlayerService = .shared) {
-        self.service = service
+    init(service: AudioPlayerService? = nil) {
+        self.service = service ?? AudioPlayerService.shared
         setupBindings()
     }
     
@@ -47,7 +47,6 @@ final class MiniPlayerViewModel {
     
     private func bindPlayerState() {
         service.playerStatePublisher
-            .receive(on: DispatchQueue.main)
             .map { state -> Bool in
                 if case .playing = state { return true }
                 return false
@@ -58,7 +57,6 @@ final class MiniPlayerViewModel {
     
     private func bindEpisodeData() {
         service.currentEpisodePublisher
-            .receive(on: DispatchQueue.main)
             .sink { [weak self] episode in
                 self?.updatePlayerMetadata(with: episode)
             }

--- a/Spokast/Features/Player/ViewModels/PlayerViewModel.swift
+++ b/Spokast/Features/Player/ViewModels/PlayerViewModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Combine
 
+@MainActor
 final class PlayerViewModel {
     
     // MARK: - Dependencies
@@ -41,20 +42,23 @@ final class PlayerViewModel {
 
     
     // MARK: - Initialization
-    init(episode: Episode,
-         podcastImageURL: URL?,
-         audioService: AudioPlayerServiceProtocol = AudioPlayerService.shared,
-         favoritesRepository: FavoritesRepositoryProtocol, downloadService: DownloadServiceProtocol = DownloadService()) {
-        
+    init(
+        episode: Episode,
+        podcastImageURL: URL?,
+        audioService: AudioPlayerServiceProtocol? = nil,
+        favoritesRepository: FavoritesRepositoryProtocol,
+        downloadService: DownloadServiceProtocol? = nil
+    ) {
         self.episode = episode
         self.podcastImageURL = podcastImageURL
-        self.audioPlayerService = audioService
         self.favoritesRepository = favoritesRepository
+        
+        self.audioPlayerService = audioService ?? AudioPlayerService.shared
+        self.downloadService = downloadService ?? DownloadService()
         
         self.title = episode.trackName
         self.artist = episode.collectionName ?? "Podcast"
         self.coverURL = podcastImageURL
-        self.downloadService = downloadService
         
         setupBindings()
         checkFavoriteStatus()

--- a/Spokast/Features/PodcastDetail/ViewModels/PodcastDetailViewModel.swift
+++ b/Spokast/Features/PodcastDetail/ViewModels/PodcastDetailViewModel.swift
@@ -8,6 +8,7 @@
 import Foundation
 import Combine
 
+@MainActor
 final class PodcastDetailViewModel {
     
     // MARK: - Properties
@@ -32,17 +33,19 @@ final class PodcastDetailViewModel {
     @Published var onDownloadsUpdate: Void?
     
     // MARK: - Initialization
-    init(podcast: Podcast,
-         repository: PodcastRepositoryProtocol = PodcastRepository(),
-         favoritesRepository: FavoritesRepositoryProtocol,
-         audioPlayerService: AudioPlayerServiceProtocol = AudioPlayerService.shared,
-         downloadService: DownloadServiceProtocol = DownloadService()) {
+    init(
+        podcast: Podcast,
+        repository: PodcastRepositoryProtocol = PodcastRepository(),
+        favoritesRepository: FavoritesRepositoryProtocol,
+        audioPlayerService: AudioPlayerServiceProtocol? = nil, // 👈 Mudança aqui
+        downloadService: DownloadServiceProtocol = DownloadService()
+    ) {
         
         self.podcast = podcast
         self.repository = repository
         self.favoritesRepository = favoritesRepository
-        self.audioPlayerService = audioPlayerService
         self.downloadService = downloadService
+        self.audioPlayerService = audioPlayerService ?? AudioPlayerService.shared
         
         setupAudioObserver()
         checkFavoriteStatus()


### PR DESCRIPTION
Description
This PR replaces the temporary UserDefaults persistence with a robust SwiftData implementation. It also performs a major architectural refactor to align the codebase with Swift 6 Strict Concurrency standards, ensuring all UI-related logic and state management occur safely on the Main Actor.

Key Changes
💾 Persistence (SwiftData)
Model: Created EpisodeProgress (@Model) to store playback timestamp, duration, and cached metadata.

Service: Implemented SwiftDataPlaybackPersistence to handle save (upsert) and load operations.

Integration: Injected the new persistence service into AudioPlayerService, enabling automatic state restoration on app launch.

🛡️ Concurrency (Swift 6 Safety)
@MainActor Enforcement: Annotated AudioPlayerService, SwiftDataPlaybackPersistence, and all related ViewModels (PlayerViewModel, MiniPlayerViewModel, PodcastDetailViewModel) with @MainActor.

init() Refactoring: Updated ViewModels to use Optional Dependency Injection instead of default arguments for singletons (.shared), resolving "Call to main actor-isolated property from non-isolated context" errors.

AVPlayer Isolation: Used MainActor.assumeIsolated in addPeriodicTimeObserver to safely bridge legacy AVFoundation callbacks to the Main Actor.

🔧 Build Settings
Disabled "Enable String Catalog Symbol Generation" to suppress Xcode warnings related to missing localization files.

How to Test
Persistence: Play an episode, pause it, kill the app, and reopen it. The player should restore the last played episode and time.

Concurrency: Build with "Strict Concurrency Checking" enabled (Swift 6 mode). The build should be free of warnings and errors.

UI: Verify that the MiniPlayer and Player screens update correctly without UI lag or threading crashes.