### PR TITLE
feat(library): implement library display and fix OPML import concurrency

### DIFF
--- a/Spokast/Core/Data/Services/LibraryService.swift
+++ b/Spokast/Core/Data/Services/LibraryService.swift
@@ -1,0 +1,35 @@
+//
+//  LibraryService.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 26/01/26.
+//
+
+import Foundation
+import SwiftData
+
+@MainActor
+protocol LibraryServiceProtocol {
+    func fetchPodcasts() throws -> [SavedPodcast]
+}
+
+@MainActor
+final class LibraryService: LibraryServiceProtocol {
+    
+    // MARK: - Dependencies
+    private let context: ModelContext
+    
+    // MARK: - Init
+    init(context: ModelContext? = nil) {
+        self.context = context ?? DatabaseService.shared.context
+    }
+    
+    // MARK: - Methods
+    func fetchPodcasts() throws -> [SavedPodcast] {
+        let descriptor = FetchDescriptor<SavedPodcast>(
+            sortBy: [SortDescriptor(\SavedPodcast.collectionName)]
+        )
+        
+        return try context.fetch(descriptor)
+    }
+}

--- a/Spokast/Features/Favorites/Cells/FavoriteCell.swift
+++ b/Spokast/Features/Favorites/Cells/FavoriteCell.swift
@@ -83,11 +83,11 @@ final class FavoriteCell: UITableViewCell {
     }
     
     // MARK: - Configuration
-    func configure(with podcast: FavoritePodcast) {
-        titleLabel.text = podcast.title
-        authorLabel.text = podcast.author
+    func configure(with podcast: SavedPodcast) {
+        titleLabel.text = podcast.collectionName
+        authorLabel.text = podcast.artistName
         
-        if let urlString = podcast.coverUrl, let url = URL(string: urlString) {
+        if let urlString = podcast.artworkUrl600, let url = URL(string: urlString) {
             
             let processor = DownsamplingImageProcessor(size: CGSize(width: 60, height: 60))
             

--- a/Spokast/Features/Favorites/Coordinator/FavoritesCoordinator.swift
+++ b/Spokast/Features/Favorites/Coordinator/FavoritesCoordinator.swift
@@ -8,7 +8,9 @@
 import Foundation
 import UIKit
 
+@MainActor
 final class FavoritesCoordinator: Coordinator {
+    
     var navigationController: UINavigationController
     
     init(navigationController: UINavigationController) {
@@ -16,22 +18,25 @@ final class FavoritesCoordinator: Coordinator {
     }
     
     func start() {
-        let repository = FavoritesRepository()
-        let viewModel = FavoritesViewModel(repository: repository)
+        let viewModel = FavoritesViewModel()
         let viewController = FavoritesViewController(viewModel: viewModel)
         viewController.coordinator = self
+        viewController.title = "Library"
         navigationController.pushViewController(viewController, animated: false)
     }
 }
 
+// MARK: - Navigation Delegate
 extension FavoritesCoordinator: PodcastSelectionDelegate {
+    
     func didSelectPodcast(_ podcast: Podcast) {
-        let favoritesRepository = FavoritesRepository()
-        let detailViewModel = PodcastDetailViewModel(podcast: podcast, favoritesRepository: favoritesRepository)
+        let legacyRepository = FavoritesRepository()
+        let detailViewModel = PodcastDetailViewModel(podcast: podcast, favoritesRepository: legacyRepository)
         let detailVC = PodcastDetailViewController(viewModel: detailViewModel)
         detailVC.coordinator = self
         navigationController.pushViewController(detailVC, animated: true)
     }
 }
+
 
 extension FavoritesCoordinator: PodcastDetailCoordinatorDelegate {}

--- a/Spokast/Features/Favorites/Views/FavoritesView.swift
+++ b/Spokast/Features/Favorites/Views/FavoritesView.swift
@@ -31,7 +31,7 @@ final class FavoritesView: UIView {
     
     private let emptyLabel: UILabel = {
         let label = UILabel()
-        label.text = "You haven't followed any podcasts yet.\nGo explore!"
+        label.text = "Your library is empty.\nImport an OPML file in Profile."
         label.textColor = .secondaryLabel
         label.textAlignment = .center
         label.numberOfLines = 0
@@ -64,11 +64,18 @@ final class FavoritesView: UIView {
             activityIndicator.stopAnimating()
             tableView.isHidden = true
             emptyLabel.isHidden = false
+            emptyLabel.text = "Your library is empty.\nImport an OPML file in Profile."
             
-        case .content:
+        case .loaded:
             activityIndicator.stopAnimating()
             tableView.isHidden = false
             emptyLabel.isHidden = true
+            
+        case .error(let message):
+            activityIndicator.stopAnimating()
+            tableView.isHidden = true
+            emptyLabel.isHidden = false
+            emptyLabel.text = message
         }
     }
     

--- a/Spokast/Features/Favorites/Views/FavoritesViewController.swift
+++ b/Spokast/Features/Favorites/Views/FavoritesViewController.swift
@@ -8,29 +8,38 @@
 import Foundation
 import UIKit
 import Combine
-import Kingfisher
 
+@MainActor
 protocol PodcastSelectionDelegate: AnyObject {
     func didSelectPodcast(_ podcast: Podcast)
 }
 
 final class FavoritesViewController: UIViewController {
     
-    // MARK: - Properties
-    private let viewModel: FavoritesViewModel
-    private var cancellables = Set<AnyCancellable>()
+    // MARK: - Dependencies
+    private let viewModel: FavoritesViewModelProtocol
     weak var coordinator: PodcastSelectionDelegate?
+    
+    // MARK: - Properties
+    private var cancellables = Set<AnyCancellable>()
+    private var podcasts: [SavedPodcast] = []
     
     private var customView: FavoritesView {
         return self.view as! FavoritesView
     }
     
     // MARK: - Init
-    init(viewModel: FavoritesViewModel) {
-        self.viewModel = viewModel
+    
+    init(viewModel: FavoritesViewModelProtocol? = nil) {
+        self.viewModel = viewModel ?? FavoritesViewModel()
         super.init(nibName: nil, bundle: nil)
-        self.title = "Favorites"
-        self.tabBarItem = UITabBarItem(tabBarSystemItem: .favorites, tag: 1)
+        
+        self.title = "Library"
+        self.tabBarItem = UITabBarItem(
+            title: "Library",
+            image: UIImage(systemName: "books.vertical"),
+            selectedImage: UIImage(systemName: "books.vertical.fill")
+        )
     }
     
     @available(*, unavailable)
@@ -39,14 +48,14 @@ final class FavoritesViewController: UIViewController {
     }
     
     // MARK: - Lifecycle
+    
     override func loadView() {
         self.view = FavoritesView()
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        customView.tableView.dataSource = self
-        customView.tableView.delegate = self
+        setupTableView()
         setupBindings()
     }
     
@@ -55,21 +64,41 @@ final class FavoritesViewController: UIViewController {
         viewModel.loadFavorites()
     }
     
-    // MARK: - Bindings
+    // MARK: - Setup
+    
+    private func setupTableView() {
+        customView.tableView.dataSource = self
+        customView.tableView.delegate = self
+    }
+    
     private func setupBindings() {
-        viewModel.$viewState
+        viewModel.statePublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] state in
-                self?.customView.updateState(state)
+                self?.handleStateChange(state)
             }
             .store(in: &cancellables)
-        
-        viewModel.$podcasts
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
-                self?.customView.tableView.reloadData()
-            }
-            .store(in: &cancellables)
+    }
+    
+    // MARK: - State Handling
+    private func handleStateChange(_ state: FavoritesViewState) {
+        switch state {
+        case .loading:
+            break
+            
+        case .empty:
+            self.podcasts = []
+            customView.tableView.reloadData()
+            
+        case .loaded(let items):
+            self.podcasts = items
+            customView.tableView.reloadData()
+            
+        case .error(let message):
+            self.podcasts = []
+            customView.tableView.reloadData()
+            print("Error state: \(message)")
+        }
     }
 }
 
@@ -77,46 +106,51 @@ final class FavoritesViewController: UIViewController {
 extension FavoritesViewController: UITableViewDataSource {
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return viewModel.podcasts.count
+        return podcasts.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: FavoriteCell.reuseIdentifier, for: indexPath) as? FavoriteCell else {
-                fatalError("Could not dequeue FavoriteCell")
-            }
-            
-            let podcast = viewModel.podcasts[indexPath.row]
-            cell.configure(with: podcast)
-            
-            return cell
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: FavoriteCell.reuseIdentifier, for: indexPath) as? FavoriteCell else {
+            return UITableViewCell()
         }
+        
+        let podcast = podcasts[indexPath.row]
+        cell.configure(with: podcast)
+        
+        return cell
+    }
 }
 
 // MARK: - UITableViewDelegate
+
 extension FavoritesViewController: UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
         
-        let favorite = viewModel.podcasts[indexPath.row]
+        let savedPodcast = podcasts[indexPath.row]
         
-        let podcastModel = Podcast(
-            trackId: Int(favorite.id),
-            artistName: favorite.author ?? "Unknown",
-            collectionName: favorite.title ?? "Unknown",
-            artworkUrl100: favorite.coverUrl ?? "",
-            feedUrl: nil,
-            artworkUrl600: favorite.coverUrl,
-            primaryGenreName: "Podcast"
+        // Mapeamento: SavedPodcast (Banco) -> Podcast (Domínio/API)
+        // Isso permite que a tela de detalhes funcione sem modificações
+        let domainPodcast = Podcast(
+            trackId: savedPodcast.collectionId,
+            artistName: savedPodcast.artistName,
+            collectionName: savedPodcast.collectionName,
+            artworkUrl100: savedPodcast.artworkUrl600 ?? "",
+            feedUrl: savedPodcast.feedUrl,
+            artworkUrl600: savedPodcast.artworkUrl600,
+            primaryGenreName: savedPodcast.primaryGenreName
         )
         
-        coordinator?.didSelectPodcast(podcastModel)
+        coordinator?.didSelectPodcast(domainPodcast)
     }
     
+    // Desabilitamos DELETE por enquanto
+    /*
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         if editingStyle == .delete {
-            viewModel.removePodcast(at: indexPath.row)
-    
+            // viewModel.removePodcast(at: indexPath.row)
         }
     }
+    */
 }

--- a/Spokast/Features/PodcastDetail/Views/PodcastDetailViewController.swift
+++ b/Spokast/Features/PodcastDetail/Views/PodcastDetailViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 import Kingfisher
 import Combine
 
+@MainActor
 protocol PodcastDetailCoordinatorDelegate: AnyObject {
     var navigationController: UINavigationController { get }
     func showEpisodeDetails(_ episode: Episode, from podcast: Podcast)


### PR DESCRIPTION
Summary
This Pull Request transitions the "Favorites" screen (now "Library") to read directly from the local database (SwiftData) using the new LibraryService. It also addresses a critical runtime crash during OPML import caused by thread isolation violations in Swift 6.

Key Changes 🛠️
Architecture & Data:

New Service: Created LibraryService to fetch SavedPodcast models, replacing the legacy FavoritesRepository for the list view.

Refactor: Updated FavoritesViewModel to consume LibraryServiceProtocol.

Model: The UI now renders SavedPodcast (SwiftData model) instead of the legacy FavoritePodcast.

Concurrency Fix (OPML Import):

Crash Fix: Refactored OPMLParser to be purely synchronous and thread-agnostic to prevent EXC_BREAKPOINT crashes related to actor isolation.

Isolation: Updated OPMLImportService to execute the XML parsing logic inside a Task.detached block, ensuring a safe "sandbox" for the Objective-C XMLParser away from the Main Actor.

UI/UX:

Updated FavoriteCell and FavoritesViewController to handle the new data model.

Added fallback logic for missing artwork (placeholders) since raw OPML data does not contain images.

Known Issues / Next Steps ⚠️
Podcasts imported via OPML currently display "Unknown Artist" and a placeholder image. This is expected behavior as OPML files do not contain this metadata.

Next PR: Will implement a SyncService to "hydrate" these records by fetching metadata from the iTunes API.

How to Test 🧪
Go to Profile and import an OPML file.

Observe that the app does not crash during import.

Go to the Library tab.

Verify that the imported podcasts appear in the list (with placeholder info).

Tap a podcast to verify navigation to the Details screen.