### PR TITLE
feat(favorites): implement library grouping by genre and fix persistence layer

### DIFF
--- a/Spokast/Features/Favorites/Models/FavoriteItem.swift
+++ b/Spokast/Features/Favorites/Models/FavoriteItem.swift
@@ -8,21 +8,34 @@
 import Foundation
 
 // MARK: - Display Models (DTOs)
-struct FavoriteItem: Hashable, Sendable {
-    let id: Int
+struct FavoriteItem: Hashable, Sendable, Identifiable {
+    let collectionId: Int
     let title: String
     let artist: String
     let artworkUrl: String?
     let feedUrl: String?
     let genre: String
     
+    // MARK: - Identifiable Compliance
+    var id: String {
+        let urlKey = feedUrl ?? "no-url"
+        return "\(collectionId)-\(urlKey)-\(title)"
+    }
+    
+    // MARK: - Hashable
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
     }
+    
+    // MARK: - Equatable
+    static func == (lhs: FavoriteItem, rhs: FavoriteItem) -> Bool {
+        return lhs.id == rhs.id
+    }
 }
 
-struct FavoritesSection: Hashable, Sendable {
+struct FavoritesSection: Hashable, Sendable, Identifiable {
     let title: String
     let items: [FavoriteItem]
+    
     var id: String { title }
 }

--- a/Spokast/Features/Favorites/Models/FavoriteItem.swift
+++ b/Spokast/Features/Favorites/Models/FavoriteItem.swift
@@ -1,0 +1,28 @@
+//
+//  FavoriteItem.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 30/01/26.
+//
+
+import Foundation
+
+// MARK: - Display Models (DTOs)
+struct FavoriteItem: Hashable, Sendable {
+    let id: Int
+    let title: String
+    let artist: String
+    let artworkUrl: String?
+    let feedUrl: String?
+    let genre: String
+    
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}
+
+struct FavoritesSection: Hashable, Sendable {
+    let title: String
+    let items: [FavoriteItem]
+    var id: String { title }
+}

--- a/Spokast/Features/Favorites/ViewModels/FavoritesViewModel.swift
+++ b/Spokast/Features/Favorites/ViewModels/FavoritesViewModel.swift
@@ -66,8 +66,8 @@ final class FavoritesViewModel: FavoritesViewModelProtocol {
         let item = section.items[indexPath.row]
         
         return Podcast(
-            trackId: item.id,
-            collectionId: item.id,
+            trackId: item.collectionId,
+            collectionId: item.collectionId,
             artistName: item.artist,
             collectionName: item.title,
             artworkUrl100: item.artworkUrl ?? "",
@@ -111,7 +111,7 @@ final class FavoritesViewModel: FavoritesViewModelProtocol {
     private func createSections(from podcasts: [SavedPodcast]) -> [FavoritesSection] {
         let items: [FavoriteItem] = podcasts.map { podcast in
             FavoriteItem(
-                id: podcast.collectionId,
+                collectionId: podcast.collectionId,
                 title: podcast.collectionName,
                 artist: podcast.artistName,
                 artworkUrl: podcast.artworkUrl600,

--- a/Spokast/Features/Favorites/ViewModels/FavoritesViewModel.swift
+++ b/Spokast/Features/Favorites/ViewModels/FavoritesViewModel.swift
@@ -8,25 +8,32 @@
 import Foundation
 import Combine
 
+// MARK: - View State
 enum FavoritesViewState: Equatable {
     case loading
     case empty
-    case loaded([SavedPodcast])
+    case loaded([FavoritesSection])
     case error(String)
 }
 
+// MARK: - Protocol
 @MainActor
 protocol FavoritesViewModelProtocol: AnyObject {
     var statePublisher: Published<FavoritesViewState>.Publisher { get }
     func loadFavorites()
+    func getPodcastDomainObject(at indexPath: IndexPath) -> Podcast?
 }
 
+// MARK: - ViewModel
 @MainActor
 final class FavoritesViewModel: FavoritesViewModelProtocol {
     
     // MARK: - Dependencies
     private let libraryService: LibraryServiceProtocol
     private let syncService: LibrarySyncServiceProtocol
+    
+    // MARK: - Data Source
+    private var currentSections: [FavoritesSection] = []
     
     // MARK: - Output
     @Published private(set) var state: FavoritesViewState = .loading
@@ -51,33 +58,77 @@ final class FavoritesViewModel: FavoritesViewModelProtocol {
         }
     }
     
-    private func fetchLocalData() {
-        if case .loading = state {
-        }
+    func getPodcastDomainObject(at indexPath: IndexPath) -> Podcast? {
+        guard indexPath.section < currentSections.count else { return nil }
+        let section = currentSections[indexPath.section]
         
+        guard indexPath.row < section.items.count else { return nil }
+        let item = section.items[indexPath.row]
+        
+        return Podcast(
+            trackId: item.id,
+            collectionId: item.id,
+            artistName: item.artist,
+            collectionName: item.title,
+            artworkUrl100: item.artworkUrl ?? "",
+            feedUrl: item.feedUrl,
+            artworkUrl600: item.artworkUrl,
+            primaryGenreName: item.genre
+        )
+    }
+    
+    // MARK: - Private Methods
+    private func fetchLocalData() {
         do {
-            let items = try libraryService.fetchPodcasts()
+            let podcasts = try libraryService.fetchPodcasts()
             
-            if items.isEmpty {
-                state = .empty
+            if podcasts.isEmpty {
+                self.currentSections = []
+                self.state = .empty
             } else {
-                state = .loaded(items)
+                let sections = createSections(from: podcasts)
+                self.currentSections = sections
+                self.state = .loaded(sections)
             }
         } catch {
             print("❌ Error fetching library: \(error)")
-            state = .error("Failed to load library.")
+            self.state = .error("Failed to load library.")
         }
     }
     
     private func performSync() async {
         do {
             let updatedCount = try await syncService.syncMissingMetadata()
-            
             if updatedCount > 0 {
                 fetchLocalData()
             }
         } catch {
             print("⚠️ Sync Warning: \(error.localizedDescription)")
         }
+    }
+    
+    // MARK: - Grouping & Mapping Logic
+    private func createSections(from podcasts: [SavedPodcast]) -> [FavoritesSection] {
+        let items: [FavoriteItem] = podcasts.map { podcast in
+            FavoriteItem(
+                id: podcast.collectionId,
+                title: podcast.collectionName,
+                artist: podcast.artistName,
+                artworkUrl: podcast.artworkUrl600,
+                feedUrl: podcast.feedUrl,
+                genre: podcast.primaryGenreName ?? "Uncategorized"
+            )
+        }
+        
+        let groupedDictionary = Dictionary(grouping: items) { item in
+            return item.genre.isEmpty ? "Uncategorized" : item.genre
+        }
+        
+        let sections = groupedDictionary.map { (key, value) -> FavoritesSection in
+            let sortedItems = value.sorted { $0.title < $1.title }
+            return FavoritesSection(title: key, items: sortedItems)
+        }
+        
+        return sections.sorted { $0.title < $1.title }
     }
 }


### PR DESCRIPTION
🚀 Summary
This PR overhauls the Library (Favorites) screen, transitioning from a basic UITableView to a modern UICollectionView with Compositional Layout and Diffable Data Source. This enables the grouping of podcasts by their primary genre (e.g., Technology, Comedy).

Additionally, this PR fixes a critical "Data Schism" bug where subscribed podcasts were not appearing in the library due to a mismatch between the writing context (Legacy Core Data) and the reading context (SwiftData).

🛠 Key Changes
User Interface:

Modern List: Replaced FavoritesViewController implementation with UICollectionView using .insetGrouped list configuration.

Sections: Implemented logic to group podcasts by primaryGenreName.

Async Images: Added Kingfisher support for efficient image loading within cell configuration, ensuring thread safety on the Main Actor.

Architecture & Logic:

DTO Pattern: Introduced FavoriteItem (DTO) to decouple the UI from the database layer, ensuring strict Sendable conformance for Swift 6 concurrency.

Identity Fix: Implemented a composite id strategy (collectionId + feedUrl) in FavoriteItem to prevent DiffableDataSource collisions for manual RSS feeds.

ViewModel: Updated FavoritesViewModel to handle data transformation and grouping logic.

Persistence (Critical Fix):

SwiftData Migration: Refactored FavoritesRepository to use SwiftData and the shared ModelContext, aligning it with LibraryService.

Sync: Resolved the issue where SavedPodcast objects were being written to a legacy Core Data stack but queried via SwiftData, resulting in an empty library.

🐛 Fixes
Fixed an issue where tapping "Subscribe" on PodcastDetail would update the UI state but fail to persist the podcast visible to the Library service.

Resolved Sendable warnings regarding Core Data objects passing through closure boundaries.