### PR TITLE
feat(library): implement custom category management

### DIFF
--- a/Spokast/Core/Data/Models/SavedPodcast.swift
+++ b/Spokast/Core/Data/Models/SavedPodcast.swift
@@ -20,6 +20,7 @@ final class SavedPodcast {
     var isSubscribed: Bool = true
     var addedAt: Date
     var category: Category?
+    var customCategory: String?
     
     init(
         collectionId: Int,
@@ -28,7 +29,8 @@ final class SavedPodcast {
         feedUrl: String? = nil,
         artworkUrl600: String? = nil,
         primaryGenreName: String? = nil,
-        category: Category? = nil
+        category: Category? = nil,
+        customCategory: String? = nil
     ) {
         self.collectionId = collectionId
         self.artistName = artistName
@@ -36,8 +38,10 @@ final class SavedPodcast {
         self.feedUrl = feedUrl
         self.artworkUrl600 = artworkUrl600
         self.primaryGenreName = primaryGenreName
+        self.isSubscribed = true
         self.addedAt = Date()
         self.category = category
+        self.customCategory = customCategory
     }
 }
 
@@ -51,7 +55,8 @@ extension SavedPodcast {
             feedUrl: apiPodcast.feedUrl,
             artworkUrl600: apiPodcast.artworkUrl600 ?? apiPodcast.artworkUrl100,
             primaryGenreName: apiPodcast.primaryGenreName,
-            category: category
+            category: category,
+            customCategory: nil 
         )
     }
 }

--- a/Spokast/Core/Data/Services/LibraryService.swift
+++ b/Spokast/Core/Data/Services/LibraryService.swift
@@ -11,6 +11,7 @@ import SwiftData
 @MainActor
 protocol LibraryServiceProtocol {
     func fetchPodcasts() throws -> [SavedPodcast]
+    func updateCategory(for podcastId: Int, to newCategory: String?) async throws
 }
 
 @MainActor
@@ -27,9 +28,23 @@ final class LibraryService: LibraryServiceProtocol {
     // MARK: - Methods
     func fetchPodcasts() throws -> [SavedPodcast] {
         let descriptor = FetchDescriptor<SavedPodcast>(
-            sortBy: [SortDescriptor(\SavedPodcast.collectionName)]
+            sortBy: [SortDescriptor(\.collectionName)]
         )
         
         return try context.fetch(descriptor)
+    }
+    
+    func updateCategory(for podcastId: Int, to newCategory: String?) async throws {
+        let idToCheck = podcastId
+        
+        var descriptor = FetchDescriptor<SavedPodcast>(
+            predicate: #Predicate { $0.collectionId == idToCheck }
+        )
+        descriptor.fetchLimit = 1
+        
+        if let podcast = try context.fetch(descriptor).first {
+            podcast.customCategory = newCategory
+            try context.save()
+        }
     }
 }

--- a/Spokast/Features/Favorites/Views/FavoritesViewController.swift
+++ b/Spokast/Features/Favorites/Views/FavoritesViewController.swift
@@ -62,7 +62,6 @@ final class FavoritesViewController: UIViewController {
     }()
     
     // MARK: - Init
-    
     init(viewModel: FavoritesViewModelProtocol? = nil) {
         self.viewModel = viewModel ?? FavoritesViewModel()
         super.init(nibName: nil, bundle: nil)
@@ -84,6 +83,7 @@ final class FavoritesViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupUI()
+        setupNavigation()
         configureDataSource()
         setupBindings()
         
@@ -119,6 +119,76 @@ final class FavoritesViewController: UIViewController {
         ])
     }
     
+    private func setupNavigation() {
+        let filterButton = UIBarButtonItem(
+            image: UIImage(systemName: "line.3.horizontal.decrease.circle"),
+            style: .plain,
+            target: nil,
+            action: nil
+        )
+        filterButton.isEnabled = false
+        navigationItem.rightBarButtonItem = filterButton
+    }
+    
+    // MARK: - Menu Logic
+    private func updateFilterMenu() {
+        guard !viewModel.availableGenres.isEmpty else {
+            navigationItem.rightBarButtonItem?.isEnabled = false
+            return
+        }
+        
+        navigationItem.rightBarButtonItem?.isEnabled = true
+        
+        let showAllAction = UIAction(
+            title: "All Categories",
+            state: viewModel.currentFilter == nil ? .on : .off
+        ) { [weak self] _ in
+            self?.viewModel.filter(by: nil)
+        }
+        
+        let genreActions = viewModel.availableGenres.map { genre in
+            UIAction(
+                title: genre,
+                state: self.viewModel.currentFilter == genre ? .on : .off
+            ) { [weak self] _ in
+                self?.viewModel.filter(by: genre)
+            }
+        }
+        
+        let menu = UIMenu(
+            title: "Filter by Genre",
+            children: [showAllAction] + genreActions
+        )
+        
+        navigationItem.rightBarButtonItem?.menu = menu
+    }
+    
+    // MARK: - User Actions (Edit Category)
+    private func presentEditCategoryAlert(for item: FavoriteItem) {
+        let alert = UIAlertController(
+            title: "Edit Category",
+            message: "Enter a custom category name for '\(item.title)'",
+            preferredStyle: .alert
+        )
+        
+        alert.addTextField { textField in
+            textField.placeholder = "Category Name (e.g. Morning Commute)"
+            textField.text = item.genre
+            textField.autocapitalizationType = .sentences
+        }
+        
+        let saveAction = UIAlertAction(title: "Save", style: .default) { [weak self, weak alert] _ in
+            guard let newName = alert?.textFields?.first?.text, !newName.trimmingCharacters(in: .whitespaces).isEmpty else { return }
+            self?.viewModel.updatePodcastCategory(podcastId: item.collectionId, newCategory: newName)
+        }
+        
+        let cancelAction = UIAlertAction(title: "Cancel", style: .cancel)
+        
+        alert.addAction(cancelAction)
+        alert.addAction(saveAction)
+        
+        present(alert, animated: true)
+    }
     
     // MARK: - Diffable Data Source Configuration
     private func configureDataSource() {
@@ -183,7 +253,7 @@ final class FavoritesViewController: UIViewController {
         guard let urlString = item.artworkUrl, let url = URL(string: urlString) else { return }
         
         let processor = DownsamplingImageProcessor(size: CGSize(width: 100, height: 100))
-        |> RoundCornerImageProcessor(cornerRadius: 8)
+                       |> RoundCornerImageProcessor(cornerRadius: 8)
         
         let options: KingfisherOptionsInfo = [
             .processor(processor),
@@ -195,7 +265,6 @@ final class FavoritesViewController: UIViewController {
         KingfisherManager.shared.retrieveImage(with: url, options: options) { [weak cell] result in
             DispatchQueue.main.async {
                 guard let cell = cell else { return }
-                
                 switch result {
                 case .success(let value):
                     if var updatedContent = cell.contentConfiguration as? UIListContentConfiguration {
@@ -210,41 +279,40 @@ final class FavoritesViewController: UIViewController {
     }
     
     // MARK: - Bindings
-    
-    private func bindViewModel() {
-        setupBindings()
-    }
-    
     private func setupBindings() {
         viewModel.statePublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] state in
-                self?.handleState(state)
+                self?.handleStateChange(state)
             }
             .store(in: &cancellables)
     }
     
-    private func handleState(_ state: FavoritesViewState) {
+    private func handleStateChange(_ state: FavoritesViewState) {
         switch state {
         case .loading:
             loadingIndicator.startAnimating()
             collectionView.isHidden = true
             emptyLabel.isHidden = true
+            navigationItem.rightBarButtonItem?.isEnabled = false
             
         case .empty:
             loadingIndicator.stopAnimating()
             collectionView.isHidden = true
             emptyLabel.isHidden = false
+            navigationItem.rightBarButtonItem?.isEnabled = false
             
         case .loaded(let sections):
             loadingIndicator.stopAnimating()
             collectionView.isHidden = false
             emptyLabel.isHidden = true
+            
+            updateFilterMenu()
             applySnapshot(sections)
             
         case .error(let message):
             loadingIndicator.stopAnimating()
-            print("Error: \(message)")
+            print("Error state: \(message)")
         }
     }
     
@@ -266,6 +334,30 @@ extension FavoritesViewController: UICollectionViewDelegate {
         
         if let domainPodcast = viewModel.getPodcastDomainObject(at: indexPath) {
             coordinator?.didSelectPodcast(domainPodcast)
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, contextMenuConfigurationForItemAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
+        
+        guard let item = dataSource.itemIdentifier(for: indexPath) else { return nil }
+        
+        return UIContextMenuConfiguration(identifier: nil, previewProvider: nil) { [weak self] _ in
+            
+            let editAction = UIAction(
+                title: "Edit Category",
+                image: UIImage(systemName: "pencil")
+            ) { _ in
+                self?.presentEditCategoryAlert(for: item)
+            }
+            
+            let resetAction = UIAction(
+                title: "Restore Default",
+                image: UIImage(systemName: "arrow.counterclockwise")
+            ) { _ in
+                self?.viewModel.updatePodcastCategory(podcastId: item.collectionId, newCategory: nil)
+            }
+            
+            return UIMenu(title: "Options", children: [editAction, resetAction])
         }
     }
 }


### PR DESCRIPTION
🚀 Summary
This PR empowers users to organize their library by creating Custom Categories. Users can now override the default Apple/RSS genre (e.g., "Technology") with their own labels (e.g., "Daily Commute", "Study"), providing a personalized organization structure.

🛠 Key Changes
Data Layer:

Schema Update: Added customCategory: String? to the SavedPodcast SwiftData model.

Migration: Relies on SwiftData lightweight migration (new property is optional/nil by default).

Service: Added updateCategory(for:to:) to LibraryService to handle database updates safely.

Logic:

Grouping Strategy: Updated FavoritesViewModel to prioritize customCategory. If nil, it falls back to primaryGenreName, and finally to "Uncategorized".

Dynamic Filtering: The previously implemented Filter Menu automatically picks up these new custom categories.

User Interface:

Context Menu: Implemented collectionView(_:contextMenuConfigurationForItemAt:) to enable Long Press interactions.

Actions:

Edit Category: Opens a native Alert with a text field.

Restore Default: Resets the category to the original RSS genre.