### PR TITLE
feat: Implement 'Mark as Played' logic, auto-completion, and episode filtering

### DIFF
--- a/Spokast/Core/Data/Models/SavedEpisode.swift
+++ b/Spokast/Core/Data/Models/SavedEpisode.swift
@@ -1,0 +1,67 @@
+//
+//  SavedEpisode.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 02/02/26.
+//
+
+import Foundation
+import SwiftData
+
+@Model
+final class SavedEpisode {
+    
+    @Attribute(.unique) var id: Int
+    var podcastId: Int
+    var title: String
+    var duration: TimeInterval
+    var releaseDate: Date?
+    var streamUrl: String?
+    var artworkUrl: String?
+    
+    // MARK: - Playback State (Core Feature)
+    var isPlayed: Bool = false
+    var playbackPosition: TimeInterval = 0.0
+    var lastPlayedAt: Date?
+    
+    // MARK: - Init
+    init(
+        id: Int,
+        podcastId: Int,
+        title: String,
+        duration: TimeInterval,
+        releaseDate: Date? = nil,
+        streamUrl: String? = nil,
+        artworkUrl: String? = nil,
+        isPlayed: Bool = false,
+        playbackPosition: TimeInterval = 0.0
+    ) {
+        self.id = id
+        self.podcastId = podcastId
+        self.title = title
+        self.duration = duration
+        self.releaseDate = releaseDate
+        self.streamUrl = streamUrl
+        self.artworkUrl = artworkUrl
+        self.isPlayed = isPlayed
+        self.playbackPosition = playbackPosition
+        self.lastPlayedAt = isPlayed ? Date() : nil
+    }
+}
+
+// MARK: - Domain Mapping
+extension SavedEpisode {
+    convenience init(from episode: Episode) {
+        self.init(
+            id: episode.trackId,
+            podcastId: episode.collectionId,
+            title: episode.trackName,
+            duration: Double(episode.durationInSeconds),
+            releaseDate: episode.releaseDate,
+            streamUrl: episode.streamUrl?.absoluteString,
+            artworkUrl: episode.artworkUrl160,
+            isPlayed: false,
+            playbackPosition: 0.0
+        )
+    }
+}

--- a/Spokast/Features/PodcastDetail/Views/Cells/EpisodeCell.swift
+++ b/Spokast/Features/PodcastDetail/Views/Cells/EpisodeCell.swift
@@ -119,7 +119,13 @@ final class EpisodeCell: UITableViewCell {
     }
     
     // MARK: - Configuration
-    func configure(with episode: Episode, downloadStatus: DownloadButton.State, podcastArtURL: URL?, isPlaying: Bool) {
+    func configure(
+        with episode: Episode,
+        downloadStatus: DownloadButton.State,
+        podcastArtURL: URL?,
+        isPlaying: Bool,
+        isPlayed: Bool
+    ) {
         titleLabel.text = episode.trackName
         
         let dateString = EpisodeCell.releaseDateFormatter.string(from: episode.releaseDate)
@@ -157,6 +163,14 @@ final class EpisodeCell: UITableViewCell {
         
         updatePlaybackState(isPlaying: isPlaying)
         downloadButton.updateState(downloadStatus)
+        
+        if isPlayed {
+            contentView.alpha = 0.5
+            accessoryType = .checkmark
+        } else {
+            contentView.alpha = 1.0
+            accessoryType = .none
+        }
     }
     
     // MARK: - Helpers


### PR DESCRIPTION
PR Description:
Summary This PR introduces the ability to track listened episodes. Users can now manually mark episodes as played/unplayed via swipe actions, and the app automatically marks episodes as played when playback finishes. Additionally, a new filter button allows users to hide played episodes from the list.

Key Changes

AudioPlayerService: Implemented a robust observer for AVPlayerItemDidPlayToEndTime using MainActor to safely trigger UI updates when a track finishes.

PodcastDetailViewModel:

Added logic to manage playedEpisodeIds.

Implemented toggleHidePlayed() to filter the episode list.

Connected to AudioPlayerService to listen for playback completion events.

PodcastDetailViewController:

Added a "Eye" toggle button to the Navigation Bar.

Implemented trailing swipe actions for manual status toggling.

EpisodeCell: Updated UI configuration to reflect played status (reduced opacity and checkmark accessory).

How to Test

Manual Toggle: Swipe an episode to the right to mark it as played/unplayed. Verify visual feedback (opacity/checkmark).

Auto-Mark: Play an episode and seek to the end. Verify if the status changes to "Played" automatically upon completion.

Filtering: Tap the "Eye" icon in the navigation bar. Played episodes should disappear/reappear.

Persistence: Restart the app and verify if the played status persists.