### PR TITLE
ci: enable caching for DerivedData and SPM to optimize build time

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -9,21 +9,34 @@ on:
 jobs:
   unit-tests:
     name: Unit Tests & Build
-    runs-on: macos-15
+    runs-on: macos-latest
 
     steps:
       - name: Code checkout
         uses: actions/checkout@v4
-            
-      - name: Run Tests
+
+      - name: Cache Derived Data & SPM
+        uses: actions/cache@v4
+        with:
+          path: DerivedData
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
+      - name: Prepare Simulator
         run: |
           DEVICE_ID=$(xcrun simctl list devices available "iPhone 16" | grep "iPhone 16 (" | head -n 1 | awk -F '[()]' '{print $2}')
+          echo "DEVICE_ID=$DEVICE_ID" >> $GITHUB_ENV
+          echo "🚀 Target Simulator ID: $DEVICE_ID"
           
           xcrun simctl boot $DEVICE_ID || true
-          
+
+      - name: Run Tests
+        run: |
           xcodebuild test \
             -scheme Spokast \
-            -destination "platform=iOS Simulator,id=$DEVICE_ID" \
+            -destination "platform=iOS Simulator,id=${{ env.DEVICE_ID }}" \
+            -derivedDataPath DerivedData \
             -enableCodeCoverage YES \
             -resultBundlePath TestResults \
             clean test


### PR DESCRIPTION
PR Description:
Summary This PR introduces caching mechanisms to our GitHub Actions pipeline. By caching DerivedData and Swift Package Manager dependencies, we aim to drastically reduce the CI execution time (currently ~38m) for subsequent runs.

Key Changes

Cache Implementation: Added actions/cache@v4 step to the workflow.

Cache Key Strategy: Configured the cache key based on runner.os and the hash of Package.resolved. If dependencies change, the cache invalidates automatically.

Xcode Build Update: Modified the xcodebuild test command to use a fixed -derivedDataPath DerivedData. This allows the CI runner to persist build artifacts between runs.

Expected Impact

First Run: Slow (Populating the cache).

Subsequent Runs: Significantly faster (Estimated 50-80% reduction), as dependencies like Kingfisher won't need to be re-downloaded or re-compiled.

Notes The Package.resolved file is essential for this strategy and has been verified in the repository.