### PR TITLE
feat: Implement Advanced Episode Sorting Options

### DIFF
--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -36,10 +36,14 @@ jobs:
             -destination "platform=iOS Simulator,name=iPhone 16" \
             -derivedDataPath DerivedData \
             -enableCodeCoverage YES \
-            -resultBundlePath TestResults \
+            -resultBundlePath TestResults.xcresult \
             -only-testing:SpokastTests \
             -disable-concurrent-destination-testing \
             test
+
+      - name: Convert xcresult to Sonar XML
+        run: |
+          bash -c "bash <(curl -s https://raw.githubusercontent.com/SonarSource/sonar-scanning-examples/master/swift-coverage/swift-coverage-example/xccov-to-sonarqube-generic.sh) TestResults.xcresult/ > coverage.xml"
 
       - name: SonarCloud Scan
         env:
@@ -56,5 +60,5 @@ jobs:
             -Dsonar.exclusions="**/DerivedData/**,**/Pods/**,**/Fastlane/**,**/*.json,**/*.xml,**/*.xib,**/*.storyboard,**/TestResults.xcresult/**" \
             -Dsonar.tests=. \
             -Dsonar.test.inclusions="**/*Tests.swift" \
-            -Dsonar.token=$SONAR_TOKEN
-            # -Dsonar.coverageReportPaths="coverage.xml"
+            -Dsonar.token=$SONAR_TOKEN \
+            -Dsonar.coverageReportPaths="coverage.xml"

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -57,8 +57,8 @@ jobs:
             -Dsonar.projectKey="rudrigaum_Spokast" \
             -Dsonar.sources=. \
             -Dsonar.host.url=https://sonarcloud.io \
-            -Dsonar.exclusions="**/DerivedData/**,**/Pods/**,**/Fastlane/**,**/*.json,**/*.xml,**/*.xib,**/*.storyboard,**/TestResults.xcresult/**" \
+            -Dsonar.exclusions="**/DerivedData/**,**/Pods/**,**/Fastlane/**,**/*.json,**/*.xml,**/*.xib,**/*.storyboard,**/TestResults.xcresult/**,**/*Mocks.swift,**/*View.swift,**/*ViewController.swift" \
             -Dsonar.tests=. \
-            -Dsonar.test.inclusions="**/*Tests.swift" \
+            -Dsonar.test.inclusions="**/*Tests.swift,**/*Mocks.swift" \
             -Dsonar.token=$SONAR_TOKEN \
             -Dsonar.coverageReportPaths="coverage.xml"

--- a/Spokast.xcodeproj/project.pbxproj
+++ b/Spokast.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		18479D342F4716F10042E2C9 /* Spokast.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = Spokast.xctestplan; sourceTree = "<group>"; };
 		187651FA2E8725F200580DBE /* Spokast.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Spokast.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		187652102E8725F600580DBE /* SpokastTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SpokastTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		1876521A2E8725F600580DBE /* SpokastUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SpokastUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -100,6 +101,7 @@
 		187651F12E8725F200580DBE = {
 			isa = PBXGroup;
 			children = (
+				18479D342F4716F10042E2C9 /* Spokast.xctestplan */,
 				187651FC2E8725F200580DBE /* Spokast */,
 				187652132E8725F600580DBE /* SpokastTests */,
 				1876521D2E8725F600580DBE /* SpokastUITests */,

--- a/Spokast.xcodeproj/xcshareddata/xcschemes/Spokast.xcscheme
+++ b/Spokast.xcodeproj/xcshareddata/xcschemes/Spokast.xcscheme
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2620"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "187651F92E8725F200580DBE"
+               BuildableName = "Spokast.app"
+               BlueprintName = "Spokast"
+               ReferencedContainer = "container:Spokast.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:Spokast.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1876520F2E8725F600580DBE"
+               BuildableName = "SpokastTests.xctest"
+               BlueprintName = "SpokastTests"
+               ReferencedContainer = "container:Spokast.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "187652192E8725F600580DBE"
+               BuildableName = "SpokastUITests.xctest"
+               BlueprintName = "SpokastUITests"
+               ReferencedContainer = "container:Spokast.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "187651F92E8725F200580DBE"
+            BuildableName = "Spokast.app"
+            BlueprintName = "Spokast"
+            ReferencedContainer = "container:Spokast.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "187651F92E8725F200580DBE"
+            BuildableName = "Spokast.app"
+            BlueprintName = "Spokast"
+            ReferencedContainer = "container:Spokast.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Spokast.xcodeproj/xcuserdata/rudrigo.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Spokast.xcodeproj/xcuserdata/rudrigo.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -10,5 +10,23 @@
 			<integer>0</integer>
 		</dict>
 	</dict>
+	<key>SuppressBuildableAutocreation</key>
+	<dict>
+		<key>187651F92E8725F200580DBE</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>1876520F2E8725F600580DBE</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+		<key>187652192E8725F600580DBE</key>
+		<dict>
+			<key>primary</key>
+			<true/>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/Spokast.xctestplan
+++ b/Spokast.xctestplan
@@ -1,0 +1,37 @@
+{
+  "configurations" : [
+    {
+      "id" : "C7A377F8-9987-42AF-BEAA-07F23D13BC2C",
+      "name" : "Test Scheme Action",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "performanceAntipatternCheckerEnabled" : true,
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:Spokast.xcodeproj",
+      "identifier" : "187651F92E8725F200580DBE",
+      "name" : "Spokast"
+    }
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : false,
+      "target" : {
+        "containerPath" : "container:Spokast.xcodeproj",
+        "identifier" : "1876520F2E8725F600580DBE",
+        "name" : "SpokastTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:Spokast.xcodeproj",
+        "identifier" : "187652192E8725F600580DBE",
+        "name" : "SpokastUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/Spokast/Core/Domain/Enums/EpisodeSorting.swift
+++ b/Spokast/Core/Domain/Enums/EpisodeSorting.swift
@@ -1,0 +1,59 @@
+//
+//  EpisodeSorting.swift
+//  Spokast
+//
+//  Created by Rodrigo Cerqueira Reis on 16/02/26.
+//
+
+import Foundation
+
+enum EpisodeSorting: String, CaseIterable, Identifiable {
+    case dateNewest = "Date (Newest)"
+    case dateOldest = "Date (Oldest)"
+    case downloadDate = "Download Date"
+    case durationShortest = "Duration (Shortest)"
+    case durationLongest = "Duration (Longest)"
+    case timeRemaining = "Time Remaining"
+    case fileSize = "File Size"
+    case titleAZ = "Title (A-Z)"
+    case titleZA = "Title (Z-A)"
+    case ratingHigh = "Rating (Highest)"
+    
+    var id: String { rawValue }
+    
+    var comparator: (Episode, Episode) -> Bool {
+        switch self {
+        case .dateNewest:
+            return { $0.releaseDate > $1.releaseDate }
+        case .dateOldest:
+            return { $0.releaseDate < $1.releaseDate }
+            
+        case .downloadDate:
+            return { lhs, rhs in
+                guard let lhsDate = lhs.downloadDate, let rhsDate = rhs.downloadDate else {
+                    return lhs.downloadDate != nil
+                }
+                return lhsDate > rhsDate
+            }
+            
+        case .durationShortest:
+            return { $0.durationInSeconds < $1.durationInSeconds }
+        case .durationLongest:
+            return { $0.durationInSeconds > $1.durationInSeconds }
+            
+        case .timeRemaining:
+            return { $0.timeRemaining < $1.timeRemaining }
+            
+        case .fileSize:
+            return { ($0.fileSize ?? 0) > ($1.fileSize ?? 0) }
+            
+        case .titleAZ:
+            return { $0.trackName.localizedCaseInsensitiveCompare($1.trackName) == .orderedAscending }
+        case .titleZA:
+            return { $0.trackName.localizedCaseInsensitiveCompare($1.trackName) == .orderedDescending }
+            
+        case .ratingHigh:
+            return { $0.rating > $1.rating }
+        }
+    }
+}

--- a/Spokast/Features/PodcastDetail/ViewModels/PodcastDetailViewModel.swift
+++ b/Spokast/Features/PodcastDetail/ViewModels/PodcastDetailViewModel.swift
@@ -9,7 +9,7 @@ import Foundation
 import Combine
 
 @MainActor
-final class PodcastDetailViewModel {
+final class PodcastDetailViewModel: ObservableObject {
     
     // MARK: - Properties
     let podcast: Podcast
@@ -33,10 +33,15 @@ final class PodcastDetailViewModel {
     @Published private(set) var isPlayerPaused: Bool = false
     @Published var isPlaying: Bool = false
     @Published var currentPlayingID: Int?
-    
     @Published private(set) var isFavorite: Bool = false
     @Published private(set) var shouldHidePlayed: Bool = false
     @Published var onDownloadsUpdate: Void?
+    
+    @Published var selectedSorting: EpisodeSorting = .dateNewest {
+        didSet {
+            applyFilters()
+        }
+    }
     
     // MARK: - Initialization
     init(
@@ -97,8 +102,8 @@ final class PodcastDetailViewModel {
                 
                 await MainActor.run {
                     self.allEpisodes = episodes
-                    self.playedEpisodeIds = playedIds // Atualiza cache
-                    self.applyFilters() // 👈 Aplica filtro inicial
+                    self.playedEpisodeIds = playedIds
+                    self.applyFilters()
                 }
             } catch {
                 await MainActor.run {
@@ -109,7 +114,7 @@ final class PodcastDetailViewModel {
         }
     }
     
-    // MARK: - Filtering Logic (Unified)
+    // MARK: - Filtering & Sorting Logic
     func filterEpisodes(with query: String) {
         self.currentSearchQuery = query
         applyFilters()
@@ -118,6 +123,10 @@ final class PodcastDetailViewModel {
     func toggleHidePlayed() {
         shouldHidePlayed.toggle()
         applyFilters()
+    }
+    
+    func updateSorting(_ sorting: EpisodeSorting) {
+        self.selectedSorting = sorting
     }
     
     private func applyFilters() {
@@ -135,6 +144,7 @@ final class PodcastDetailViewModel {
             result = result.filter { !playedEpisodeIds.contains($0.trackId) }
         }
         
+        result = result.sorted(by: selectedSorting.comparator)
         self.episodes = result
     }
     
@@ -149,7 +159,7 @@ final class PodcastDetailViewModel {
         } else {
             playedEpisodeIds.insert(episode.trackId)
         }
-        applyFilters() // Re-filtra a lista imediatamente
+        applyFilters()
         
         Task {
             do {

--- a/Spokast/Features/PodcastDetail/Views/PodcastDetailView.swift
+++ b/Spokast/Features/PodcastDetail/Views/PodcastDetailView.swift
@@ -10,6 +10,9 @@ import UIKit
 
 final class PodcastDetailView: UIView {
 
+    // MARK: - Actions
+    var didSelectSortOption: ((EpisodeSorting) -> Void)?
+
     // MARK: - UI Components
     lazy var tableView: UITableView = {
         let tableView = UITableView()
@@ -65,12 +68,29 @@ final class PodcastDetailView: UIView {
         return button
     }()
     
-    private lazy var artistStackView: UIStackView = {
-        let stack = UIStackView(arrangedSubviews: [artistLabel, subscribeButton])
+    lazy var sortButton: UIButton = {
+        var config = UIButton.Configuration.tinted()
+        config.cornerStyle = .medium
+        config.baseBackgroundColor = .secondarySystemBackground
+        config.baseForegroundColor = .label
+        config.image = UIImage(systemName: "arrow.up.arrow.down")
+        config.imagePlacement = .leading
+        config.imagePadding = 8
+        config.title = "Sort"
+        
+        let button = UIButton(configuration: config)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.heightAnchor.constraint(equalToConstant: 34).isActive = true
+        button.showsMenuAsPrimaryAction = true
+        return button
+    }()
+    
+    private lazy var buttonsStackView: UIStackView = {
+        let stack = UIStackView(arrangedSubviews: [subscribeButton, sortButton])
         stack.axis = .horizontal
         stack.spacing = 12
         stack.alignment = .center
-        stack.distribution = .fill
+        stack.distribution = .fillProportionally
         return stack
     }()
     
@@ -84,7 +104,7 @@ final class PodcastDetailView: UIView {
     }()
 
     private lazy var headerStackView: UIStackView = {
-        let stack = UIStackView(arrangedSubviews: [imageView, titleLabel, artistStackView, genreLabel])
+        let stack = UIStackView(arrangedSubviews: [imageView, titleLabel, artistLabel, buttonsStackView, genreLabel])
         stack.translatesAutoresizingMaskIntoConstraints = false
         stack.axis = .vertical
         stack.spacing = 16
@@ -94,7 +114,7 @@ final class PodcastDetailView: UIView {
     
     private let headerContainerView: UIView = {
         let view = UIView()
-        view.frame = CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 400)
+        view.frame = CGRect(x: 0, y: 0, width: UIScreen.main.bounds.width, height: 450)
         return view
     }()
 
@@ -114,7 +134,27 @@ final class PodcastDetailView: UIView {
         titleLabel.text = viewModel.title
         artistLabel.text = viewModel.artist
         genreLabel.text = viewModel.genre.uppercased()
+        configureSortMenu(currentSelection: viewModel.selectedSorting)
+        
         layoutTableHeaderView()
+    }
+
+    private func configureSortMenu(currentSelection: EpisodeSorting) {
+        let actions = EpisodeSorting.allCases.map { sortOption in
+            UIAction(
+                title: sortOption.rawValue,
+                state: sortOption == currentSelection ? .on : .off,
+                handler: { [weak self] _ in
+                    self?.didSelectSortOption?(sortOption)
+                    self?.sortButton.configuration?.title = sortOption.rawValue
+                    self?.configureSortMenu(currentSelection: sortOption)
+                }
+            )
+        }
+        
+        let menu = UIMenu(title: "Sort Episodes By", children: actions)
+        sortButton.menu = menu
+        sortButton.configuration?.title = currentSelection.rawValue
     }
     
     func updateSubscribeButton(isSubscribed: Bool) {

--- a/Spokast/Features/PodcastDetail/Views/PodcastDetailView.swift
+++ b/Spokast/Features/PodcastDetail/Views/PodcastDetailView.swift
@@ -139,7 +139,7 @@ final class PodcastDetailView: UIView {
         layoutTableHeaderView()
     }
 
-    private func configureSortMenu(currentSelection: EpisodeSorting) {
+    func configureSortMenu(currentSelection: EpisodeSorting) {
         let actions = EpisodeSorting.allCases.map { sortOption in
             UIAction(
                 title: sortOption.rawValue,

--- a/Spokast/Features/PodcastDetail/Views/PodcastDetailView.swift
+++ b/Spokast/Features/PodcastDetail/Views/PodcastDetailView.swift
@@ -12,6 +12,7 @@ final class PodcastDetailView: UIView {
 
     // MARK: - Actions
     var didSelectSortOption: ((EpisodeSorting) -> Void)?
+    var didTapSortButton: (() -> Void)?
 
     // MARK: - UI Components
     lazy var tableView: UITableView = {
@@ -59,12 +60,13 @@ final class PodcastDetailView: UIView {
         config.cornerStyle = .capsule
         config.baseBackgroundColor = .systemPurple
         config.baseForegroundColor = .white
-        config.title = "SUBSCRIBE"
-        config.contentInsets = NSDirectionalEdgeInsets(top: 6, leading: 16, bottom: 6, trailing: 16)
+        config.title = "Subscribe"
         
         let button = UIButton(configuration: config)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.heightAnchor.constraint(equalToConstant: 34).isActive = true
+        button.setContentCompressionResistancePriority(.required, for: .horizontal)
+        button.titleLabel?.numberOfLines = 1
         return button
     }()
     
@@ -75,13 +77,15 @@ final class PodcastDetailView: UIView {
         config.baseForegroundColor = .label
         config.image = UIImage(systemName: "arrow.up.arrow.down")
         config.imagePlacement = .leading
-        config.imagePadding = 8
+        config.imagePadding = 6
         config.title = "Sort"
+        config.contentInsets = NSDirectionalEdgeInsets(top: 6, leading: 12, bottom: 6, trailing: 12)
         
         let button = UIButton(configuration: config)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.heightAnchor.constraint(equalToConstant: 34).isActive = true
-        button.showsMenuAsPrimaryAction = true
+        button.showsMenuAsPrimaryAction = false
+        button.addTarget(self, action: #selector(handleSortTap), for: .touchUpInside)
         return button
     }()
     
@@ -90,7 +94,7 @@ final class PodcastDetailView: UIView {
         stack.axis = .horizontal
         stack.spacing = 12
         stack.alignment = .center
-        stack.distribution = .fillProportionally
+        stack.distribution = .fill
         return stack
     }()
     
@@ -134,43 +138,29 @@ final class PodcastDetailView: UIView {
         titleLabel.text = viewModel.title
         artistLabel.text = viewModel.artist
         genreLabel.text = viewModel.genre.uppercased()
-        configureSortMenu(currentSelection: viewModel.selectedSorting)
-        
         layoutTableHeaderView()
     }
 
-    func configureSortMenu(currentSelection: EpisodeSorting) {
-        let actions = EpisodeSorting.allCases.map { sortOption in
-            UIAction(
-                title: sortOption.rawValue,
-                state: sortOption == currentSelection ? .on : .off,
-                handler: { [weak self] _ in
-                    self?.didSelectSortOption?(sortOption)
-                    self?.sortButton.configuration?.title = sortOption.rawValue
-                    self?.configureSortMenu(currentSelection: sortOption)
-                }
-            )
-        }
-        
-        let menu = UIMenu(title: "Sort Episodes By", children: actions)
-        sortButton.menu = menu
-        sortButton.configuration?.title = currentSelection.rawValue
+    @objc private func handleSortTap() {
+        didTapSortButton?()
     }
     
     func updateSubscribeButton(isSubscribed: Bool) {
         var config = subscribeButton.configuration
+        subscribeButton.titleLabel?.numberOfLines = 1
+        subscribeButton.titleLabel?.adjustsFontSizeToFitWidth = true
         
         if isSubscribed {
             config?.baseBackgroundColor = .systemGray5
             config?.baseForegroundColor = .secondaryLabel
-            config?.title = "SUBSCRIBED"
+            config?.title = "Subscribed"
             config?.image = UIImage(systemName: "checkmark")
-            config?.imagePadding = 6
+            config?.imagePadding = 4
             config?.imagePlacement = .leading
         } else {
             config?.baseBackgroundColor = .systemPurple
             config?.baseForegroundColor = .white
-            config?.title = "SUBSCRIBE"
+            config?.title = "Subscribe"
             config?.image = nil
         }
         

--- a/Spokast/Features/PodcastDetail/Views/PodcastDetailViewController.swift
+++ b/Spokast/Features/PodcastDetail/Views/PodcastDetailViewController.swift
@@ -102,8 +102,8 @@ final class PodcastDetailViewController: UIViewController {
     // MARK: - Actions Setup
     private func setupActions() {
         customView?.subscribeButton.addTarget(self, action: #selector(didTapSubscribe), for: .touchUpInside)
-        customView?.didSelectSortOption = { [weak self] selectedOption in
-            self?.viewModel.updateSorting(selectedOption)
+        customView?.didTapSortButton = { [weak self] in
+            self?.presentSortOptions()
         }
     }
     
@@ -132,6 +132,28 @@ final class PodcastDetailViewController: UIViewController {
         }
     }
     
+    private func presentSortOptions() {
+        let alert = UIAlertController(title: "Sort Episodes By", message: nil, preferredStyle: .actionSheet)
+        
+        for option in EpisodeSorting.allCases {
+            let isSelected = option == viewModel.selectedSorting
+            let title = isSelected ? "✓ \(option.rawValue)" : option.rawValue
+            
+            let action = UIAlertAction(title: title, style: .default) { [weak self] _ in
+                self?.viewModel.updateSorting(option)
+            }
+            alert.addAction(action)
+        }
+        
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel))
+        
+        if let popover = alert.popoverPresentationController {
+            popover.sourceView = customView?.sortButton
+            popover.sourceRect = customView?.sortButton.bounds ?? .zero
+        }
+        present(alert, animated: true)
+    }
+    
     // MARK: - Bindings
     private func setupBindings() {
         bindEpisodes()
@@ -140,16 +162,6 @@ final class PodcastDetailViewController: UIViewController {
         bindSubscriptionState()
         bindDownloads()
         bindNavigationState()
-        bindSortingState()
-    }
-    
-    private func bindSortingState() {
-        viewModel.$selectedSorting
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] sorting in
-                self?.customView?.configureSortMenu(currentSelection: sorting)
-            }
-            .store(in: &cancellables)
     }
     
     private func bindEpisodes() {

--- a/Spokast/Features/PodcastDetail/Views/PodcastDetailViewController.swift
+++ b/Spokast/Features/PodcastDetail/Views/PodcastDetailViewController.swift
@@ -33,7 +33,7 @@ final class PodcastDetailViewController: UIViewController {
         search.searchResultsUpdater = self
         search.obscuresBackgroundDuringPresentation = false
         search.searchBar.placeholder = "Search episodes"
-        search.hidesNavigationBarDuringPresentation = false 
+        search.hidesNavigationBarDuringPresentation = false
         return search
     }()
     
@@ -102,6 +102,9 @@ final class PodcastDetailViewController: UIViewController {
     // MARK: - Actions Setup
     private func setupActions() {
         customView?.subscribeButton.addTarget(self, action: #selector(didTapSubscribe), for: .touchUpInside)
+        customView?.didSelectSortOption = { [weak self] selectedOption in
+            self?.viewModel.updateSorting(selectedOption)
+        }
     }
     
     @objc private func didTapSubscribe() {
@@ -137,6 +140,16 @@ final class PodcastDetailViewController: UIViewController {
         bindSubscriptionState()
         bindDownloads()
         bindNavigationState()
+        bindSortingState()
+    }
+    
+    private func bindSortingState() {
+        viewModel.$selectedSorting
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] sorting in
+                self?.customView?.configureSortMenu(currentSelection: sorting)
+            }
+            .store(in: &cancellables)
     }
     
     private func bindEpisodes() {
@@ -247,9 +260,10 @@ final class PodcastDetailViewController: UIViewController {
             let cell = getCell(for: episode)
             let sourceButton = cell?.downloadButton
             
-            presentDeleteConfirmation(for: episode, sourceView: sourceButton) { [weak self] in
-                self?.viewModel.deleteEpisode(episode)
-            }
+
+             presentDeleteConfirmation(for: episode, sourceView: sourceButton) { [weak self] in
+                 self?.viewModel.deleteEpisode(episode)
+             }
             
         } else {
             viewModel.toggleDownload(for: episode)
@@ -289,7 +303,7 @@ extension PodcastDetailViewController: UITableViewDataSource {
             downloadStatus: downloadStatus,
             podcastArtURL: podcastArtURL,
             isPlaying: isPlayingThisEpisode,
-            isPlayed: isPlayed 
+            isPlayed: isPlayed
         )
         
         cell.onPlayTap = { [weak self] in
@@ -315,7 +329,7 @@ extension PodcastDetailViewController: UITableViewDelegate {
     }
     
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return 300
+        return UITableView.automaticDimension
     }
     
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
@@ -340,19 +354,14 @@ extension PodcastDetailViewController: UITableViewDelegate {
     }
 }
 
+// MARK: - Coordinator Delegate
+
 extension PodcastDetailCoordinatorDelegate {
-    
-    func showEpisodeDetails(_ episode: Episode, from podcast: Podcast) {
-        let viewModel = EpisodeDetailViewModel(episode: episode, podcast: podcast)
-        let episodeDetailVC = EpisodeDetailViewController(viewModel: viewModel)
-        
-        navigationController.pushViewController(episodeDetailVC, animated: true)
-    }
+    func showEpisodeDetails(_ episode: Episode, from podcast: Podcast) {}
 }
 
 // MARK: - UISearchResultsUpdating
 extension PodcastDetailViewController: UISearchResultsUpdating {
-
     func updateSearchResults(for searchController: UISearchController) {
         guard let text = searchController.searchBar.text else { return }
         viewModel.filterEpisodes(with: text)

--- a/Spokast/Models/Episode.swift
+++ b/Spokast/Models/Episode.swift
@@ -7,7 +7,9 @@
 
 import Foundation
 
-struct Episode: Codable, Identifiable {
+struct Episode: Codable, Identifiable, Equatable {
+    
+    // MARK: - API Properties
     var id: Int { trackId }
     let trackId: Int
     let trackName: String
@@ -22,9 +24,21 @@ struct Episode: Codable, Identifiable {
     let artworkUrl600: String?
     let artistName: String?
     
+    // MARK: - Local State
+    var downloadDate: Date? = nil
+    var fileSize: Int64? = nil
+    var playbackProgress: Double = 0.0
+    var rating: Int = 0
+    
+    // MARK: - Computed Properties
     var durationInSeconds: Double {
         guard let millis = trackTimeMillis else { return 0.0 }
         return Double(millis) / 1000.0
+    }
+    
+    var timeRemaining: Double {
+        let total = durationInSeconds
+        return max(0, total - playbackProgress)
     }
     
     var streamUrl: URL? {
@@ -34,6 +48,7 @@ struct Episode: Codable, Identifiable {
         return nil
     }
     
+    // MARK: - CodingKeys
     enum CodingKeys: String, CodingKey {
         case trackId
         case trackName
@@ -50,6 +65,7 @@ struct Episode: Codable, Identifiable {
     }
 }
 
+// MARK: - Extensions
 extension Episode {
     var asPodcast: Podcast {
         return Podcast(

--- a/SpokastTests/Domain/EpisodeSortingTests.swift
+++ b/SpokastTests/Domain/EpisodeSortingTests.swift
@@ -1,0 +1,73 @@
+//
+//  EpisodeSortingTests.swift
+//  SpokastTests
+//
+//  Created by Rodrigo Cerqueira Reis on 16/02/26.
+//
+
+import Foundation
+import XCTest
+@testable import Spokast
+
+final class EpisodeSortingTests: XCTestCase {
+    
+    private func makeEpisode(
+        id: Int = 1,
+        title: String = "Test",
+        date: Date = Date(),
+        duration: Double = 100,
+        downloadDate: Date? = nil,
+        progress: Double = 0
+    ) -> Episode {
+        return Episode(
+            trackId: id,
+            trackName: title,
+            description: nil,
+            releaseDate: date,
+            trackTimeMillis: Int(duration * 1000), 
+            previewUrl: nil,
+            episodeUrl: "http://test.com",
+            artworkUrl160: nil,
+            collectionName: nil,
+            collectionId: 0,
+            artworkUrl600: nil,
+            artistName: nil,
+            downloadDate: downloadDate,
+            playbackProgress: progress
+        )
+    }
+    
+    func testSortByDateNewest() {
+        let old = makeEpisode(date: Date().addingTimeInterval(-1000))
+        let new = makeEpisode(date: Date())
+        
+        let sorted = [old, new].sorted(by: EpisodeSorting.dateNewest.comparator)
+        
+        XCTAssertEqual(sorted.first, new, "Should be ordered Newest -> Oldest")
+    }
+    
+    func testSortByDownloadDate_PutsDownloadedFirst() {
+        let notDownloaded = makeEpisode(downloadDate: nil)
+        let downloaded = makeEpisode(downloadDate: Date())
+        
+        let sorted = [notDownloaded, downloaded].sorted(by: EpisodeSorting.downloadDate.comparator)
+        
+        XCTAssertEqual(sorted.first, downloaded, "Downloaded episodes should come first")
+    }
+    
+    func testSortByTimeRemaining() {
+        let epNearEnd = makeEpisode(duration: 100, progress: 90)
+        let epNotStarted = makeEpisode(duration: 100, progress: 0)
+        let sorted = [epNotStarted, epNearEnd].sorted(by: EpisodeSorting.timeRemaining.comparator)
+        XCTAssertEqual(sorted.first, epNearEnd, "Episode with less time remaining should come first")
+    }
+    
+    func testSortByTitle_IgnoresCase() {
+        let epA = makeEpisode(title: "apple")
+        let epB = makeEpisode(title: "Banana")
+        
+        let sorted = [epB, epA].sorted(by: EpisodeSorting.titleAZ.comparator)
+        
+        XCTAssertEqual(sorted.first, epA, "Apple comes before Banana")
+    }
+}

--- a/SpokastTests/Domain/EpisodeSortingTests.swift
+++ b/SpokastTests/Domain/EpisodeSortingTests.swift
@@ -12,30 +12,34 @@ import XCTest
 final class EpisodeSortingTests: XCTestCase {
     
     private func makeEpisode(
-        id: Int = 1,
-        title: String = "Test",
-        date: Date = Date(),
-        duration: Double = 100,
-        downloadDate: Date? = nil,
-        progress: Double = 0
-    ) -> Episode {
-        return Episode(
-            trackId: id,
-            trackName: title,
-            description: nil,
-            releaseDate: date,
-            trackTimeMillis: Int(duration * 1000), 
-            previewUrl: nil,
-            episodeUrl: "http://test.com",
-            artworkUrl160: nil,
-            collectionName: nil,
-            collectionId: 0,
-            artworkUrl600: nil,
-            artistName: nil,
-            downloadDate: downloadDate,
-            playbackProgress: progress
-        )
-    }
+            id: Int = 1,
+            title: String = "Test",
+            date: Date = Date(),
+            duration: Double = 100,
+            downloadDate: Date? = nil,
+            progress: Double = 0,
+            fileSize: Int64? = nil,
+            rating: Int = 0
+        ) -> Episode {
+            return Episode(
+                trackId: id,
+                trackName: title,
+                description: nil,
+                releaseDate: date,
+                trackTimeMillis: Int(duration * 1000),
+                previewUrl: nil,
+                episodeUrl: "http://test.com",
+                artworkUrl160: nil,
+                collectionName: nil,
+                collectionId: 0,
+                artworkUrl600: nil,
+                artistName: nil,
+                downloadDate: downloadDate,
+                fileSize: fileSize,
+                playbackProgress: progress,
+                rating: rating
+            )
+        }
     
     func testSortByDateNewest() {
         let old = makeEpisode(date: Date().addingTimeInterval(-1000))
@@ -69,5 +73,66 @@ final class EpisodeSortingTests: XCTestCase {
         let sorted = [epB, epA].sorted(by: EpisodeSorting.titleAZ.comparator)
         
         XCTAssertEqual(sorted.first, epA, "Apple comes before Banana")
+    }
+    
+    // MARK: - Episode Sorting Domain Tests
+    func test_sorting_dateNewestAndOldest() {
+        let oldDate = Date().addingTimeInterval(-86400)
+        let newDate = Date()
+        
+        let oldEp = makeEpisode(id: 1, date: oldDate)
+        let newEp = makeEpisode(id: 2, date: newDate)
+        
+        XCTAssertTrue(EpisodeSorting.dateNewest.comparator(newEp, oldEp), "Date Newest failed")
+        XCTAssertTrue(EpisodeSorting.dateOldest.comparator(oldEp, newEp), "Date Oldest failed")
+    }
+    
+    func test_sorting_downloadDate() {
+        let oldDownload = Date().addingTimeInterval(-3600)
+        let newDownload = Date()
+        
+        let ep1 = makeEpisode(id: 1, downloadDate: oldDownload)
+        let ep2 = makeEpisode(id: 2, downloadDate: newDownload)
+        let epSemDownload = makeEpisode(id: 3, downloadDate: nil)
+        
+        XCTAssertTrue(EpisodeSorting.downloadDate.comparator(ep2, ep1), "Download Date failed to prioritize newer")
+        XCTAssertTrue(EpisodeSorting.downloadDate.comparator(ep1, epSemDownload), "Download Date failed to prioritize downloaded")
+    }
+    
+    func test_sorting_durationLongestAndShortest() {
+        let shortEp = makeEpisode(id: 1, duration: 60)
+        let longEp = makeEpisode(id: 2, duration: 3600)
+        
+        XCTAssertTrue(EpisodeSorting.durationLongest.comparator(longEp, shortEp), "Duration Longest failed")
+        XCTAssertTrue(EpisodeSorting.durationShortest.comparator(shortEp, longEp), "Duration Shortest failed")
+    }
+    
+    func test_sorting_timeRemaining() {
+        let lessTimeEp = makeEpisode(id: 1, duration: 100, progress: 90)
+        let moreTimeEp = makeEpisode(id: 2, duration: 100, progress: 10)
+        
+        XCTAssertTrue(EpisodeSorting.timeRemaining.comparator(lessTimeEp, moreTimeEp), "Time Remaining failed")
+    }
+    
+    func test_sorting_fileSize() {
+        let smallEp = makeEpisode(id: 1, fileSize: 1024)
+        let largeEp = makeEpisode(id: 2, fileSize: 5048)
+        
+        XCTAssertTrue(EpisodeSorting.fileSize.comparator(largeEp, smallEp), "File Size failed")
+    }
+    
+    func test_sorting_titleAZandZA() {
+        let epA = makeEpisode(id: 1, title: "Apple")
+        let epZ = makeEpisode(id: 2, title: "Zebra")
+        
+        XCTAssertTrue(EpisodeSorting.titleAZ.comparator(epA, epZ), "Title A-Z failed")
+        XCTAssertTrue(EpisodeSorting.titleZA.comparator(epZ, epA), "Title Z-A failed")
+    }
+    
+    func test_sorting_ratingHigh() {
+        let lowRatingEp = makeEpisode(id: 1, rating: 2)
+        let highRatingEp = makeEpisode(id: 2, rating: 5)
+        
+        XCTAssertTrue(EpisodeSorting.ratingHigh.comparator(highRatingEp, lowRatingEp), "Rating High failed")
     }
 }

--- a/SpokastTests/Mocks/PodcastDetailMocks.swift
+++ b/SpokastTests/Mocks/PodcastDetailMocks.swift
@@ -1,0 +1,163 @@
+//
+//  PodcastDetailMocks.swift
+//  SpokastTests
+//
+//  Created by Rodrigo Cerqueira Reis on 19/02/26.
+//
+
+import Foundation
+import Combine
+@testable import Spokast
+
+// MARK: - Mock Podcast Repository
+final class MockPodcastRepository: PodcastRepositoryProtocol {
+    var episodesToReturn: [Episode]
+    var errorToThrow: Error?
+    
+    init(episodes: [Episode] = []) {
+        self.episodesToReturn = episodes
+    }
+    
+    func fetchEpisodes(for id: Int) async throws -> [Episode] {
+        if let error = errorToThrow { throw error }
+        return episodesToReturn
+    }
+}
+
+// MARK: - Mock Favorites Repository
+final class MockFavoritesRepository: FavoritesRepositoryProtocol {
+    var isFollowed = false
+    var followedPodcastsToReturn: [SavedPodcast] = []
+    var isEpisodeLikedValue = false
+    
+    // MARK: - Protocol Conformance
+    func isPodcastFollowed(id: Int) -> Bool {
+        return isFollowed
+    }
+    
+    func togglePodcastSubscription(for podcast: Podcast) throws -> Bool {
+        isFollowed.toggle()
+        return isFollowed
+    }
+    
+    func fetchFollowedPodcasts() -> [SavedPodcast] {
+        return followedPodcastsToReturn
+    }
+    
+    func toggleEpisodeLike(for episode: Episode) throws -> Bool {
+        isEpisodeLikedValue.toggle()
+        return isEpisodeLikedValue
+    }
+    
+    func isEpisodeLiked(id: Int) -> Bool {
+        return isEpisodeLikedValue
+    }
+}
+
+// MARK: - Mock Library Service
+final class MockLibraryService: LibraryServiceProtocol {
+    var podcastsToReturn: [SavedPodcast] = []
+    var playedIdsToReturn: Set<Int> = []
+    var lastUpdatedCategory: String?
+    var lastUpdatedPodcastId: Int?
+    
+    func fetchPodcasts() throws -> [SavedPodcast] {
+        return podcastsToReturn
+    }
+    
+    func updateCategory(for podcastId: Int, to newCategory: String?) async throws {
+        self.lastUpdatedPodcastId = podcastId
+        self.lastUpdatedCategory = newCategory
+    }
+    
+    func getPlayedEpisodeIds(for podcastId: Int) throws -> Set<Int> {
+        return playedIdsToReturn
+    }
+    
+    func toggleEpisodePlayedStatus(_ episode: Episode) async throws -> Bool {
+        if playedIdsToReturn.contains(episode.trackId) {
+            playedIdsToReturn.remove(episode.trackId)
+            return false
+        } else {
+            playedIdsToReturn.insert(episode.trackId)
+            return true
+        }
+    }
+}
+
+// MARK: - Mock Download Service
+final class MockDownloadService: DownloadServiceProtocol {
+    var activeDownloadsPublisher = CurrentValueSubject<[URL: DownloadStatus], Never>([:])
+    
+    var localFiles: [Int: URL] = [:]
+    
+    // MARK: - Protocol Methods
+    func hasLocalFile(for episode: Episode) -> URL? {
+        return localFiles[episode.trackId]
+    }
+    
+    func startDownload(for episode: Episode) {
+    }
+    
+    func cancelDownload(for episode: Episode) {
+    }
+    
+    func deleteLocalFile(for episode: Episode) {
+        localFiles.removeValue(forKey: episode.trackId)
+    }
+}
+
+// MARK: - Mock Audio Player Service
+final class MockAudioPlayerService: AudioPlayerServiceProtocol {
+    
+    // MARK: - Protocol Publishers (Assinaturas Exatas)
+    var playerStatePublisher = CurrentValueSubject<AudioPlayerState, Never>(.stopped)
+    var progressPublisher = PassthroughSubject<(currentTime: Double, duration: Double), Never>()
+    var currentEpisodePublisher = CurrentValueSubject<Episode?, Never>(nil)
+    var playbackRatePublisher = CurrentValueSubject<Float, Never>(1.0)
+    var playbackDidEndPublisher = PassthroughSubject<Void, Never>()
+    
+    // MARK: - Protocol Properties
+    var currentEpisode: Episode?
+    var currentPodcastImageURL: URL?
+    
+    // MARK: - Protocol Methods
+    func play(episode: Episode, from podcast: Podcast) {
+        self.currentEpisode = episode
+        self.currentEpisodePublisher.send(episode)
+        
+        if let url = URL(string: "https://spokast.mock/audio.mp3") {
+            self.playerStatePublisher.send(.playing(url: url))
+        }
+    }
+    
+    func play(url: URL) {
+        playerStatePublisher.send(.playing(url: url))
+    }
+    
+    func pause() {
+        if case .playing(let url) = playerStatePublisher.value {
+            playerStatePublisher.send(.paused(url: url))
+        }
+    }
+    
+    func stop() {
+        playerStatePublisher.send(.stopped)
+    }
+    
+    func toggle(url: URL) {
+        switch playerStatePublisher.value {
+        case .playing(let currentUrl) where currentUrl == url:
+            pause()
+        default:
+            play(url: url)
+        }
+    }
+    
+    func seek(to time: Double) {
+    }
+    
+    func setPlaybackRate(_ rate: Float) {
+        playbackRatePublisher.send(rate)
+    }
+}

--- a/SpokastTests/Presentation/PodcastDetailViewModelTests.swift
+++ b/SpokastTests/Presentation/PodcastDetailViewModelTests.swift
@@ -1,0 +1,94 @@
+//
+//  PodcastDetailViewModelTests.swift
+//  SpokastTests
+//
+//  Created by Rodrigo Cerqueira Reis on 19/02/26.
+//
+
+import Foundation
+import XCTest
+import Combine
+@testable import Spokast
+
+@MainActor
+final class PodcastDetailViewModelTests: XCTestCase {
+    
+    private var cancellables: Set<AnyCancellable>!
+    
+    override func setUp() {
+        super.setUp()
+        cancellables = []
+    }
+    
+    override func tearDown() {
+        cancellables = nil
+        super.tearDown()
+    }
+    
+    // MARK: - Helper
+    private func makeSUT(episodes: [Episode]) -> PodcastDetailViewModel {
+        let podcast = Podcast(trackId: 1, collectionId: 1, artistName: "Test", collectionName: "Test Pod", artworkUrl100: "", feedUrl: nil, artworkUrl600: nil, primaryGenreName: nil)
+        
+        let sut = PodcastDetailViewModel(
+            podcast: podcast,
+            repository: MockPodcastRepository(episodes: episodes),
+            favoritesRepository: MockFavoritesRepository(),
+            libraryService: MockLibraryService(),
+            audioPlayerService: MockAudioPlayerService(),
+            downloadService: MockDownloadService()
+        )
+        return sut
+    }
+    
+    // MARK: - Tests
+    func test_updateSorting_shouldReorderEpisodesByDuration() async {
+        let epShort = createEpisode(id: 1, duration: 60)
+        let epLong = createEpisode(id: 2, duration: 3600)
+        let sut = makeSUT(episodes: [epLong, epShort])
+        
+        sut.fetchEpisodes()
+        
+        try? await Task.sleep(nanoseconds: 500_000_000)
+        
+        sut.updateSorting(.durationShortest)
+        
+        try? await Task.sleep(nanoseconds: 500_000_000)     
+        
+        XCTAssertEqual(sut.episodes.first?.id, epShort.id, "The shortest episode should be the first in the list.")
+        XCTAssertEqual(sut.episodes.last?.id, epLong.id, "The longest episode should be the last.")
+    }
+    
+    func test_updateSorting_shouldReorderEpisodesByTitle() async {
+        let epZ = createEpisode(id: 1, title: "Zebra")
+        let epA = createEpisode(id: 2, title: "Apple")
+        let sut = makeSUT(episodes: [epZ, epA])
+        
+        sut.fetchEpisodes()
+        
+        try? await Task.sleep(nanoseconds: 500_000_000)
+        
+        sut.updateSorting(.titleAZ)
+    
+        try? await Task.sleep(nanoseconds: 500_000_000)
+        
+        XCTAssertEqual(sut.episodes.first?.trackName, "Apple", "Alphabetical sorting (A-Z) failed.")
+    }
+    
+    // MARK: - Factory Methods
+    private func createEpisode(id: Int, title: String = "Test", duration: Double = 100) -> Episode {
+        return Episode(
+            trackId: id,
+            trackName: title,
+            description: nil,
+            releaseDate: Date(),
+            trackTimeMillis: Int(duration * 1000),
+            previewUrl: nil,
+            episodeUrl: nil,
+            artworkUrl160: nil,
+            collectionName: nil,
+            collectionId: 0,
+            artworkUrl600: nil,
+            artistName: nil
+        )
+    }
+}


### PR DESCRIPTION
🚀 Summary
This PR implements the ability to sort podcast episodes by various criteria (Date, Duration, Download Status, etc.). It encompasses changes from the Domain layer down to the UI, ensuring a clean separation of concerns using MVVM-C.

🛠 Key Changes
Domain & Data:

Updated Episode entity to support mutable local state (download date, playback progress).

Created EpisodeSorting enum implementing the Strategy Pattern for sorting logic.

Added Unit Tests for sorting strategies (EpisodeSortingTests).

Presentation (MVVM):

Updated PodcastDetailViewModel to expose selectedSorting and automatically re-sort the list upon change.

Integrated EpisodeSorting comparator into the filtering pipeline.

UI (UIKit):

Refactored PodcastDetailView header to include a simplified "Sort" button.

Implemented an Action Sheet (UIAlertController) in PodcastDetailViewController to handle sort selection, improving UX for long option titles compared to the previous UIMenu approach.

📸 Screenshots
(Anexe aqui os prints que você tirou: o botão novo e a Action Sheet aberta)

🧪 How to Test
Go to a Podcast Detail screen.

Tap the "Sort" button in the header.

Select "Duration (Longest)". verify the list updates instantly.

Select "Date (Oldest)" and verify the order reverses.

✅ Checklist
[x] Unit Tests passed.

[x] Layout constraints verified on small screens (iPhone SE).

[x] No retain cycles in closures.